### PR TITLE
Increase node-exporter tolerations

### DIFF
--- a/katalog/node-exporter/deploy.yml
+++ b/katalog/node-exporter/deploy.yml
@@ -47,8 +47,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - operator: Exists
       volumes:
       - hostPath:
           path: /proc


### PR DESCRIPTION
The set of tolerations of node-exporter daemonset is too restricted, in this way it'll tolerate *any* taint applied to nodes and won't need "special" Kustomize patches to get correctly scheduled.