### PR TITLE
Update kube-state-metrics to v1.8.0

### DIFF
--- a/katalog/kube-state-metrics/README.md
+++ b/katalog/kube-state-metrics/README.md
@@ -26,7 +26,7 @@ From kube-state-metrics
 
 ## Image repository and tag
 
-* kube-state-metrics image: `quay.io/coreos/kube-state-metrics:v1.5.0`
+* kube-state-metrics image: `quay.io/coreos/kube-state-metrics:v1.8.0`
 * kube-state-metrics repository:
   https://github.com/kubernetes/kube-state-metrics
 
@@ -35,9 +35,9 @@ From kube-state-metrics
 
 Fury distribution kube-state-metrics is deployed with following configuration:
 - Resource limits are `100m` for CPU and `150Mi` for memory
-- Listens on port `8081`
-- Exposes kubernetes-related metrics on port `8081` and metrics about itself on
-  port `8082`
+- Listens on port `8080`
+- Exposes kubernetes-related metrics on port `8080` and metrics about itself on
+  port `8081`
 - Metrics are scraped by Prometheus with `30s` intervals
 
 

--- a/katalog/kube-state-metrics/deploy.yml
+++ b/katalog/kube-state-metrics/deploy.yml
@@ -46,7 +46,7 @@ spec:
             cpu: 100m
             memory: 150Mi
       - name: addon-resizer
-        image: quay.io/coreos/addon-resizer:1.8.4
+        image: k8s.gcr.io/addon-resizer:1.8.4
         command:
         - /pod_nanny
         - --container=kube-state-metrics

--- a/katalog/kube-state-metrics/deploy.yml
+++ b/katalog/kube-state-metrics/deploy.yml
@@ -1,28 +1,43 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: kube-state-metrics
   labels:
     app: kube-state-metrics
-  name: kube-state-metrics
-  namespace: monitoring
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kube-state-metrics
+  replicas: 1
   template:
     metadata:
       labels:
         app: kube-state-metrics
     spec:
+      serviceAccountName: kube-state-metrics
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       containers:
-      - args:
-        - --host=0.0.0.0
-        - --port=8081
-        - --telemetry-host=0.0.0.0
-        - --telemetry-port=8082
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
-        name: kube-state-metrics
+      - name: kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.8.0
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-metrics
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http-metrics
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
         resources:
           limits:
             cpu: 100m
@@ -30,7 +45,9 @@ spec:
           requests:
             cpu: 100m
             memory: 150Mi
-      - command:
+      - name: addon-resizer
+        image: quay.io/coreos/addon-resizer:1.8.4
+        command:
         - /pod_nanny
         - --container=kube-state-metrics
         - --cpu=100m
@@ -50,8 +67,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: quay.io/coreos/addon-resizer:1.0
-        name: addon-resizer
         resources:
           limits:
             cpu: 10m
@@ -59,26 +74,21 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-      serviceAccountName: kube-state-metrics
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    k8s-app: kube-state-metrics
   name: kube-state-metrics
-  namespace: monitoring
+  labels:
+    app: kube-state-metrics
 spec:
   clusterIP: None
   ports:
-  - name: http-main
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
     port: 8081
-    targetPort: 8081
-  - name: http-self
-    port: 8082
-    targetPort: 8082
+    targetPort: telemetry
   selector:
     app: kube-state-metrics

--- a/katalog/kube-state-metrics/kustomization.yaml
+++ b/katalog/kube-state-metrics/kustomization.yaml
@@ -1,6 +1,6 @@
 namespace: monitoring
 
-resources: 
-  - deploy.yml
-  - rbac.yml
-  - sm.yml
+resources:
+- deploy.yml
+- rbac.yml
+- sm.yml

--- a/katalog/kube-state-metrics/rbac.yml
+++ b/katalog/kube-state-metrics/rbac.yml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,6 +27,7 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
   - extensions
   resources:
   - daemonsets
@@ -34,9 +40,14 @@ rules:
   - apps
   resources:
   - statefulsets
-  - daemonsets
-  - deployments
-  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
   verbs:
   - list
   - watch
@@ -55,6 +66,64 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  resourceNames:
+  - kube-state-metrics
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  resourceNames:
+  - kube-state-metrics
+  verbs:
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -67,44 +136,11 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-  namespace: monitoring
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: kube-state-metrics
-  namespace: monitoring
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resourceNames:
-  - kube-state-metrics
-  resources:
-  - deployments
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - apps
-  resourceNames:
-  - kube-state-metrics
-  resources:
-  - deployments
-  verbs:
-  - get
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kube-state-metrics
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -112,9 +148,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kube-state-metrics
-  namespace: monitoring

--- a/katalog/kube-state-metrics/sm.yml
+++ b/katalog/kube-state-metrics/sm.yml
@@ -1,21 +1,20 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  name: kube-state-metrics
   labels:
     k8s-app: kube-state-metrics
-  name: kube-state-metrics
-  namespace: monitoring
 spec:
   endpoints:
   - honorLabels: true
     interval: 30s
-    port: http-main
+    port: http-metrics
     scheme: http
     scrapeTimeout: 30s
   - interval: 30s
-    port: http-self
+    port: telemetry
     scheme: http
   jobLabel: k8s-app
   selector:
     matchLabels:
-      k8s-app: kube-state-metrics
+      app: kube-state-metrics


### PR DESCRIPTION
The aim of this PR is to update kube-state-metrics to v1.8.0.

Please note that I explicitely ignored the new `kube-state-metrics` sharding/autosharding mechanism but I kept the `addon-resizer` sidecar.

If we want, we can address the sharding/autosharding feature in a separate PR once it becomes more stable.