### PR TITLE
Adding new test. Marking module version 1.1.0 incompatible with Kubernetes 1.16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,14 +40,14 @@ steps:
       event:
       - push
 
-  - name: integration-test-1.16
-    image: quay.io/sighup/kind:v0.5.1_v1.16.2_3.2.2
+  - name: integration-test-1.14
+    image: quay.io/sighup/kind:v0.5.1_v1.14.6_3.2.2
     pull: always
     depends_on: [ clone ]
     environment:
       CLUSTER_HOST: docker
       TESTS: katalog/tests/tests.bats
-      NAME: "116"
+      NAME: "114"
     volumes:
       - name: dockersock
         path: /var/run
@@ -70,14 +70,14 @@ steps:
       event:
       - push
 
-  - name: integration-test-1.14
-    image: quay.io/sighup/kind:v0.5.1_v1.14.6_3.2.2
+  - name: integration-test-1.16
+    image: quay.io/sighup/kind:v0.5.1_v1.16.2_3.2.2
     pull: always
     depends_on: [ clone ]
     environment:
       CLUSTER_HOST: docker
       TESTS: katalog/tests/tests.bats
-      NAME: "114"
+      NAME: "116"
     volumes:
       - name: dockersock
         path: /var/run

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ specific dependencies please visit the single package's documentation:
 | Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             |
 |-------------------------------------|:------------------:|:------------------:|:------------------:|
 | v1.0.0                              |                    | :white_check_mark: |                    |
-| v1.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.1.0                              | :white_check_mark: | :white_check_mark: | :x:                |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/katalog/tests/tests.bats
+++ b/katalog/tests/tests.bats
@@ -25,8 +25,14 @@ apply (){
 }
 
 @test "testing alertmanager-operated apply" {
+  patch(){
+    kubectl patch alertmanager main -n monitoring -p='[{"op": "add", "path": "/spec/replicas", "value": 2}]' --type json
+  }
   run apply katalog/alertmanager-operated
-  [ "$status" -eq 0 ]
+  apply_result="$status"
+  run patch
+  patch_result="$status"
+  [ "$apply_result" -eq 0 ] && [ "$patch_result" -eq 0 ]
 }
 
 @test "testing grafana apply" {
@@ -45,6 +51,8 @@ apply (){
 }
 
 @test "wait for apply to settle and dump state to dump.json" {
+  echo "Waiting 30 seconds to prometheus-operator to spin up alertmanager-operated and prometheus-operated" >&2
+  sleep 30
   max_retry=0
   echo "=====" $max_retry "=====" >&2
   while kubectl get pods --all-namespaces | grep -ie "\(Pending\|Error\|CrashLoop\|ContainerCreating\)" >&2
@@ -55,96 +63,96 @@ apply (){
   done
 }
 
-#@test "check prometheus-operator exists" {
-  #test(){
-    #kubectl get deployment --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "prometheus-operator")'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" != "" ]
-#}
+@test "check prometheus-operator exists" {
+  test(){
+    kubectl get deployment --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "prometheus-operator")'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" != "" ]
+}
 
-#@test "check prometheus-operator status" {
-  #test(){
-    #kubectl get deployment --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "prometheus-operator" and .status.replicas != .status.currentReplicas )'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" == "" ]
-#}
+@test "check prometheus-operator status" {
+  test(){
+    kubectl get deployment --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "prometheus-operator" and .status.replicas != .status.availableReplicas )'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" == "" ]
+}
 
-#@test "check alertmanager-operated exists" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "alertmanager-main")'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" != "" ]
-#}
+@test "check alertmanager-operated exists" {
+  test(){
+    kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "alertmanager-main")'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" != "" ]
+}
 
-#@test "check alertmanager-operated status" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "alertmanager-main" and .status.replicas != .status.readyReplicas )'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" == "" ]
-#}
+@test "check alertmanager-operated status" {
+  test(){
+    kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "alertmanager-main" and .status.replicas != .status.readyReplicas )'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" == "" ]
+}
 
 
-#@test "check node-exporter exists" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "alertmanager-main" )'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" != "" ]
-#}
+@test "check node-exporter exists" {
+  test(){
+    kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "DaemonSet" and .metadata.name == "node-exporter" )'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" != "" ]
+}
 
-#@test "check node-exporter status" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "alertmanager-main" and .status.replicas != .status.currentReplicas )'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" == "" ]
-#}
+@test "check node-exporter status" {
+  test(){
+    kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "DaemonSet" and .metadata.name == "node-exporter" and .status.desiredNumberScheduled != .status.numberReady )'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" == "" ]
+}
 
-#@test "check grafana exists" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "grafana")'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" != "" ]
-#}
+@test "check grafana exists" {
+  test(){
+    kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "grafana")'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" != "" ]
+}
 
-#@test "check grafana status" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "grafana" and .status.replicas != .status.currentReplicas )'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" == "" ]
-#}
+@test "check grafana status" {
+  test(){
+    kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "Deployment" and .metadata.name == "grafana" and .status.replicas != .status.availableReplicas )'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" == "" ]
+}
 
-#@test "check prometheus-operated exists" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "prometheus-k8s")'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" != "" ]
-#}
+@test "check prometheus-operated exists" {
+  test(){
+      kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "prometheus-k8s")'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" != "" ]
+}
 
-#@test "check prometheus-operated status" {
-  #test(){
-     #kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "prometheus-k8s" and .status.replicas != .status.readyReplicas )'
-  #}
-  #run test
-  #echo "$output" | jq '.' >&2
-  #[ "$output" == "" ]
-#}
+@test "check prometheus-operated status" {
+  test(){
+      kubectl get all --all-namespaces -o json | jq '.items[] | select( .kind == "StatefulSet" and .metadata.name == "prometheus-k8s" and .status.replicas != .status.readyReplicas )'
+  }
+  run test
+  echo "$output" | jq '.' >&2
+  [ "$output" == "" ]
+}
 
 @test "cleanup" {
   if [ -z "${LOCAL_DEV_ENV}" ];


### PR DESCRIPTION
Hi team.

The idea of this pull requests is to **activate old test** refactoring some of them to certify that our monitoring module is compatible with `kubernetes` versions `1.14`, `1.15` and `1.16`.

But... We found that it's not compatible with `1.16` because of api version deprecations in Kubernetes `1.16`.

It could be resolved if we update the prometheus-operator version from `0.29` to >`0.30`.
https://github.com/coreos/prometheus-operator/blob/master/CHANGELOG.md#0300--2019-05-10

There is also a new changed required by kubernetes > 1.14 that fails in kubernetes 1.16 *(thanks @lnovara)*:

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#action-required-2

~~I will try to add a "test" to certify we are fully compatible with 1.16. Do you think is worthy?~~
I will try to adapt it (manually) all the queries in this repository to be complaint with those changes applied >1.14 version. I will open a new PR with all changes needed to by 1.16 compatible

Thanks!