### PR TITLE
Add 1.16 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ resources in these repositories are going to be deployed in `monitoring`
 namespace in your Kubernetes cluster.
 
 - [prometheus-operator](katalog/prometheus-operator): Operator to deploy and
-  manage Prometheus and related resources. Version: **0.29.0**
+  manage Prometheus and related resources. Version: **0.30.0**
 - [prometheus-operated](katalog/prometheus-operated): Prometheus instance
   deployed with Prometheus Operator's CRD. Version: **2.7.1**
 - [alertmanager-operated](katalog/alertmanager-operated): Alertmanager instance

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ namespace in your Kubernetes cluster.
 - [kubeadm-sm](katalog/kubeadm-sm): Service Monitors, Prometheus rules and
   alerts for Kubernetes components of unmanaged/on-promise clusters.
 - [kube-state-metrics](katalog/kube-state-metrics): Service Monitor for
-  Kubernetes objects such as Deployments, Nodes and Pods. Version: **1.5.0**
+  Kubernetes objects such as Deployments, Nodes and Pods. Version: **1.8.0**
 - [node-exporter](katalog/node-exporter): Service Monitor for hardware and OS
   metrics exposed by \*NIX kernels. Version: **0.16.0**
 

--- a/katalog/grafana/dashboards/kubernetes-deployments.json
+++ b/katalog/grafana/dashboards/kubernetes-deployments.json
@@ -82,7 +82,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\",container_name!=\"POD\",container_name!=\"\"}[3m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$deployment_namespace\",pod=~\"$deployment_name.*\",container!=\"POD\",container!=\"\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -165,7 +165,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\",container_name!=\"POD\",container_name!=\"\"})",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$deployment_namespace\",pod=~\"$deployment_name.*\",container!=\"POD\",container!=\"\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -249,7 +249,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$deployment_namespace\",pod=~\"$deployment_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$deployment_namespace\",pod=~\"$deployment_name.*\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -788,7 +788,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod) (label_replace(rate(container_cpu_usage_seconds_total{job=\"kubelet\",container_name!=\"POD\",container_name!=\"\"}[1m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))",
+          "expr": "sum by (namespace,pod) (label_replace(rate(container_cpu_usage_seconds_total{job=\"kubelet\",container!=\"POD\",container!=\"\"}[1m]), \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -887,7 +887,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod) (label_replace(container_memory_usage_bytes{job=\"kubelet\",container_name!=\"POD\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))",
+          "expr": "sum by (namespace,pod) (label_replace(container_memory_usage_bytes{job=\"kubelet\",container!=\"POD\",container!=\"\"}, \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -986,7 +986,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod) (label_replace(rate(container_network_transmit_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))\n + \nsum by (namespace,pod) (label_replace(rate(container_network_receive_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))",
+          "expr": "sum by (namespace,pod) (label_replace(rate(container_network_transmit_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))\n + \nsum by (namespace,pod) (label_replace(rate(container_network_receive_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$deployment_name.*\",namespace=\"$deployment_namespace\"}))",
           "format": "time_series",
           "hide": false,
           "interval": "",

--- a/katalog/grafana/dashboards/kubernetes-nodes.json
+++ b/katalog/grafana/dashboards/kubernetes-nodes.json
@@ -442,11 +442,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod_name) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", container_name!=\"POD\", container_name!=\"\"}[1m]) * on(namespace, pod_name) group_left(node) label_replace(node_namespace_pod:kube_pod_info:{node=\"$node\"}, \"pod_name\", \"$1\", \"pod\", \"(.*)\"))",
+          "expr": "sum by (namespace,pod) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", container!=\"POD\", container!=\"\"}[1m]) * on(namespace, pod) group_left(node) label_replace(node_namespace_pod:kube_pod_info:{node=\"$node\"}, \"pod\", \"$1\", \"pod\", \"(.*)\"))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{ namespace }}/{{ pod_name }}",
+          "legendFormat": "{{ namespace }}/{{ pod }}",
           "refId": "A"
         }
       ],
@@ -831,11 +831,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod_name) (container_memory_usage_bytes{job=\"kubelet\", container_name!=\"POD\", container_name!=\"\"} * on(namespace, pod_name) group_left(node) label_replace(node_namespace_pod:kube_pod_info:{node=\"$node\"}, \"pod_name\", \"$1\", \"pod\", \"(.*)\"))",
+          "expr": "sum by (namespace,pod) (container_memory_usage_bytes{job=\"kubelet\", container!=\"POD\", container!=\"\"} * on(namespace, pod) group_left(node) label_replace(node_namespace_pod:kube_pod_info:{node=\"$node\"}, \"pod\", \"$1\", \"pod\", \"(.*)\"))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{ namespace }}/{{ pod_name }}",
+          "legendFormat": "{{ namespace }}/{{ pod }}",
           "refId": "A"
         }
       ],

--- a/katalog/grafana/dashboards/kubernetes-pods.json
+++ b/katalog/grafana/dashboards/kubernetes-pods.json
@@ -72,11 +72,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{job=\"kubelet\",container_name!=\"POD\",container_name!=\"\",namespace=\"$namespace\",pod_name=\"$pod\",container_name=~\"$container\"}[1m])",
+          "expr": "rate(container_cpu_usage_seconds_total{job=\"kubelet\",container!=\"POD\",container!=\"\",namespace=\"$namespace\",pod=\"$pod\",container=~\"$container\"}[1m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{ pod_name }}/{{ container_name }} current",
+          "legendFormat": "{{ pod }}/{{ container }} current",
           "refId": "A"
         },
         {
@@ -182,11 +182,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{job=\"kubelet\",container_name!=\"POD\",container_name!=\"\",namespace=\"$namespace\",pod_name=\"$pod\",container_name=~\"$container\"}",
+          "expr": "container_memory_usage_bytes{job=\"kubelet\",container!=\"POD\",container!=\"\",namespace=\"$namespace\",pod=\"$pod\",container=~\"$container\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{ pod_name }}/{{ container_name }} current",
+          "legendFormat": "{{ pod }}/{{ container }} current",
           "refId": "A"
         },
         {
@@ -292,7 +292,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod_name) (rate(container_network_transmit_bytes_total{job=\"kubelet\",namespace=\"$namespace\",pod_name=\"$pod\"}[1m]))",
+          "expr": "sum by (namespace,pod) (rate(container_network_transmit_bytes_total{job=\"kubelet\",namespace=\"$namespace\",pod=\"$pod\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -300,7 +300,7 @@
           "refId": "B"
         },
         {
-          "expr": "-(sum by (namespace,pod_name) (rate(container_network_receive_bytes_total{job=\"kubelet\",namespace=\"$namespace\",pod_name=\"$pod\"}[1m])))",
+          "expr": "-(sum by (namespace,pod) (rate(container_network_receive_bytes_total{job=\"kubelet\",namespace=\"$namespace\",pod=\"$pod\"}[1m])))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,

--- a/katalog/grafana/dashboards/kubernetes-statefulsets.json
+++ b/katalog/grafana/dashboards/kubernetes-statefulsets.json
@@ -79,7 +79,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubelet\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"POD\", container_name!=\"\"}[3m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"kubelet\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"POD\", container!=\"\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -160,7 +160,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{job=\"kubelet\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"POD\", container_name!=\"\"})",
+          "expr": "sum(container_memory_usage_bytes{job=\"kubelet\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"POD\", container!=\"\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -241,7 +241,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod_name=~\"$statefulset.*\"}[3m]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\", namespace=\"$namespace\", pod=~\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -767,7 +767,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod) (label_replace(rate(container_cpu_usage_seconds_total{job=\"kubelet\",container_name!=\"POD\",container_name!=\"\"}[1m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))",
+          "expr": "sum by (namespace,pod) (label_replace(rate(container_cpu_usage_seconds_total{job=\"kubelet\",container!=\"POD\",container!=\"\"}[1m]), \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -866,7 +866,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod) (label_replace(container_memory_usage_bytes{job=\"kubelet\",container_name!=\"POD\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))",
+          "expr": "sum by (namespace,pod) (label_replace(container_memory_usage_bytes{job=\"kubelet\",container!=\"POD\",container!=\"\"}, \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -1150,7 +1150,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace,pod) (label_replace(rate(container_network_transmit_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))\n + \nsum by (namespace,pod) (label_replace(rate(container_network_receive_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod_name\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))",
+          "expr": "sum by (namespace,pod) (label_replace(rate(container_network_transmit_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))\n + \nsum by (namespace,pod) (label_replace(rate(container_network_receive_bytes_total{job=\"kubelet\"}[1m]), \"pod\", \"$1\", \"pod\", \"(.*)\") * on (namespace,pod) group_left(created_by_name) (kube_pod_info{created_by_name=~\"$statefulset.*\",namespace=\"$namespace\"}))",
           "format": "time_series",
           "hide": false,
           "interval": "",

--- a/katalog/prometheus-operated/rules.yml
+++ b/katalog/prometheus-operated/rules.yml
@@ -11,42 +11,42 @@ spec:
   - name: k8s.rules
     rules:
     - expr: |
-        sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])) by (namespace)
+        sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!=""}[5m])) by (namespace)
       record: namespace:container_cpu_usage_seconds_total:sum_rate
     - expr: |
-        sum by (namespace, pod_name, container_name) (
-          rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])
+        sum by (namespace, pod, container) (
+          rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!=""}[5m])
         )
       record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
     - expr: |
-        sum(container_memory_usage_bytes{job="kubelet", image!="", container_name!=""}) by (namespace)
+        sum(container_memory_usage_bytes{job="kubelet", image!="", container!=""}) by (namespace)
       record: namespace:container_memory_usage_bytes:sum
     - expr: |
         sum by (namespace, label_name) (
-           sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])) by (namespace, pod_name)
-         * on (namespace, pod_name) group_left(label_name)
-           label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+           sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!=""}[5m])) by (namespace, pod)
+         * on (namespace, pod) group_left(label_name)
+           label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")
         )
       record: namespace_name:container_cpu_usage_seconds_total:sum_rate
     - expr: |
         sum by (namespace, label_name) (
-          sum(container_memory_usage_bytes{job="kubelet",image!="", container_name!=""}) by (pod_name, namespace)
-        * on (namespace, pod_name) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+          sum(container_memory_usage_bytes{job="kubelet",image!="", container!=""}) by (pod, namespace)
+        * on (namespace, pod) group_left(label_name)
+          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")
         )
       record: namespace_name:container_memory_usage_bytes:sum
     - expr: |
         sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}) by (namespace, pod)
         * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")
         )
       record: namespace_name:kube_pod_container_resource_requests_memory_bytes:sum
     - expr: |
         sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} and on(pod) kube_pod_status_scheduled{condition="true"}) by (namespace, pod)
         * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")
         )
       record: namespace_name:kube_pod_container_resource_requests_cpu_cores:sum
   - name: kube-apiserver.rules

--- a/katalog/prometheus-operator/deploy.yml
+++ b/katalog/prometheus-operator/deploy.yml
@@ -20,8 +20,8 @@ spec:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.30.0
+        image: quay.io/coreos/prometheus-operator:v0.30.0
         name: prometheus-operator
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Hi team!

I have adapted this module to be compatible with kubernetes 1.16.

As a recap:

1. Modified grafana dashboards (queries)
2. Modified alerts rules (queries)
3. Upgraded prometheus-operator from 0.29 -> 0.30

This changes was caused by the kubernetes api version deprecations.

All queries has been tested against a local environment. 

Thanks!