### PR TITLE
Add release docs 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ specific dependencies please visit the single package's documentation:
 | v1.0.0                              |                    | :white_check_mark: |                    |
 | v1.1.0                              | :white_check_mark: | :white_check_mark: | :x:                |
 | v1.2.0                              | :white_check_mark: | :white_check_mark: | :x:                |
+| v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,10 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.2.0` and this release: `1.3.0`
+
+- Added Kubernetes 1.16 compatibility.
+  - Updated [`prometheus-operator`](../../katalog/prometheus-operator/) from `0.29.0` to `0.30.0`.
+- Added [`Goldpinger`](../../katalog/goldpinger) deployment.
+- Updated [`kube-state-metrics`](../../katalog/kube-state-metrics) from `1.5.0` to `1.8.0`.


### PR DESCRIPTION
Hi team. 

I wanted to release a new monitoring module version. I increased a minor version because we include new features (goldpinger). 

Once this PR got merged, it's needed to create a git tag in the master branch.

```bash
$ git pull origin master
$ git tag v1.3.0
$ git push --tags
```

Thanks!