### PR TITLE
Add metric to keep track of systemd machine ID

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 tag = True
 current_version = 1.5.0-rc1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-rc{rc}
 	{major}.{minor}.{patch}
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,60 @@
+[bumpversion]
+commit = True
+tag = True
+current_version = 1.4.1
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
+serialize =
+	{major}.{minor}.{patch}-rc{rc}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:README.md]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/alertmanager-configuration/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/alertmanager-operated-deployment/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/grafana-add-dashboard/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/grafana-configuration/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/grafana-remove-dashboard/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/prometheus-additionalScrapes/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/prometheus-alertmanager-externalUrl/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/prometheus-externalLabels/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/prometheus-operated-deployment/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/prometheus-operated-nodeSelector/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/prometheus-rules/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}
+
+[bumpversion:file:examples/serviceMonitor/Furyfile.yml]
+search = version: v{current_version}
+replace = version: v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.4.1
+current_version = 1.5.0-rc1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-rc{rc}
 	{major}.{minor}.{patch}
 
@@ -58,3 +58,4 @@ replace = version: v{new_version}
 [bumpversion:file:examples/serviceMonitor/Furyfile.yml]
 search = version: v{current_version}
 replace = version: v{new_version}
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,7 +35,6 @@ steps:
       - bats -t examples/tests.sh
     when:
       event:
-      - push
       - tag
 
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc5
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -89,7 +89,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc5
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -122,7 +122,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc5
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -163,7 +163,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc5
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -196,7 +196,7 @@ platform:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc5
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     volumes:
     - name: shared
@@ -237,7 +237,7 @@ steps:
           - refs/tags/**
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.0-rc5
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.2.1
     pull: always
     depends_on: [ e2e ]
     settings:

--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ and Grafana using the following `Furyfile.yml` :
 ```yaml
 bases:
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/alertmanager-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/node-exporter
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/kube-state-metrics
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/grafana
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/goldpinger
-    version: v1.4.1
+    version: v1.5.0-rc1
 ```
 and execute
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ specific dependencies please visit the single package's documentation:
 | v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v1.4.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v1.4.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.5.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues
@@ -88,19 +89,19 @@ and Grafana using the following `Furyfile.yml` :
 ```yaml
 bases:
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/alertmanager-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/node-exporter
-    version: master
+    version: v1.4.1
   - name: monitoring/kube-state-metrics
-    version: master
+    version: v1.4.1
   - name: monitoring/grafana
-    version: master
+    version: v1.4.1
   - name: monitoring/goldpinger
-    version: master
+    version: v1.4.1
 ```
 and execute
 ```bash

--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -1,0 +1,11 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.4.1` and this release: `1.5.0`
+
+- Add a `machine-id` textfile recolector in `node-exporter`:
+  - Add `systemd_machine_id` metric.
+  - Closing #21
+- Add an alert to monitor `machine-id` collisions:
+  - Alert name: `NodeMachineIDCollision`

--- a/examples/alertmanager-configuration/Furyfile.yml
+++ b/examples/alertmanager-configuration/Furyfile.yml
@@ -1,5 +1,5 @@
 bases:
   - name: monitoring/alertmanager-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1

--- a/examples/alertmanager-configuration/Furyfile.yml
+++ b/examples/alertmanager-configuration/Furyfile.yml
@@ -1,5 +1,5 @@
 bases:
   - name: monitoring/alertmanager-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1

--- a/examples/alertmanager-operated-deployment/Furyfile.yml
+++ b/examples/alertmanager-operated-deployment/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/alertmanager-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/alertmanager-operated-deployment/Furyfile.yml
+++ b/examples/alertmanager-operated-deployment/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/alertmanager-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/examples/grafana-add-dashboard/Furyfile.yml
+++ b/examples/grafana-add-dashboard/Furyfile.yml
@@ -1,3 +1,3 @@
 bases:
   - name: monitoring/grafana
-    version: master
+    version: v1.4.1

--- a/examples/grafana-add-dashboard/Furyfile.yml
+++ b/examples/grafana-add-dashboard/Furyfile.yml
@@ -1,3 +1,3 @@
 bases:
   - name: monitoring/grafana
-    version: v1.4.1
+    version: v1.5.0-rc1

--- a/examples/grafana-configuration/Furyfile.yml
+++ b/examples/grafana-configuration/Furyfile.yml
@@ -1,3 +1,3 @@
 bases:
   - name: monitoring/grafana
-    version: master
+    version: v1.4.1

--- a/examples/grafana-configuration/Furyfile.yml
+++ b/examples/grafana-configuration/Furyfile.yml
@@ -1,3 +1,3 @@
 bases:
   - name: monitoring/grafana
-    version: v1.4.1
+    version: v1.5.0-rc1

--- a/examples/grafana-remove-dashboard/Furyfile.yml
+++ b/examples/grafana-remove-dashboard/Furyfile.yml
@@ -1,3 +1,3 @@
 bases:
   - name: monitoring/grafana
-    version: master
+    version: v1.4.1

--- a/examples/grafana-remove-dashboard/Furyfile.yml
+++ b/examples/grafana-remove-dashboard/Furyfile.yml
@@ -1,3 +1,3 @@
 bases:
   - name: monitoring/grafana
-    version: v1.4.1
+    version: v1.5.0-rc1

--- a/examples/prometheus-additionalScrapes/Furyfile.yml
+++ b/examples/prometheus-additionalScrapes/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/prometheus-additionalScrapes/Furyfile.yml
+++ b/examples/prometheus-additionalScrapes/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/examples/prometheus-alertmanager-externalUrl/Furyfile.yml
+++ b/examples/prometheus-alertmanager-externalUrl/Furyfile.yml
@@ -1,8 +1,8 @@
 bases:
   - name: monitoring/alertmanager-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/examples/prometheus-alertmanager-externalUrl/Furyfile.yml
+++ b/examples/prometheus-alertmanager-externalUrl/Furyfile.yml
@@ -1,8 +1,8 @@
 bases:
   - name: monitoring/alertmanager-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/prometheus-externalLabels/Furyfile.yml
+++ b/examples/prometheus-externalLabels/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/prometheus-externalLabels/Furyfile.yml
+++ b/examples/prometheus-externalLabels/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/examples/prometheus-operated-deployment/Furyfile.yml
+++ b/examples/prometheus-operated-deployment/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/prometheus-operated-deployment/Furyfile.yml
+++ b/examples/prometheus-operated-deployment/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/examples/prometheus-operated-nodeSelector/Furyfile.yml
+++ b/examples/prometheus-operated-nodeSelector/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/prometheus-operated-nodeSelector/Furyfile.yml
+++ b/examples/prometheus-operated-nodeSelector/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/examples/prometheus-rules/Furyfile.yml
+++ b/examples/prometheus-rules/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/prometheus-rules/Furyfile.yml
+++ b/examples/prometheus-rules/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/examples/serviceMonitor/Furyfile.yml
+++ b/examples/serviceMonitor/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: master
+    version: v1.4.1
   - name: monitoring/prometheus-operator
-    version: master
+    version: v1.4.1
 

--- a/examples/serviceMonitor/Furyfile.yml
+++ b/examples/serviceMonitor/Furyfile.yml
@@ -1,6 +1,6 @@
 bases:
   - name: monitoring/prometheus-operated
-    version: v1.4.1
+    version: v1.5.0-rc1
   - name: monitoring/prometheus-operator
-    version: v1.4.1
+    version: v1.5.0-rc1
 

--- a/katalog/node-exporter/deploy.yml
+++ b/katalog/node-exporter/deploy.yml
@@ -13,6 +13,17 @@ spec:
       labels:
         app: node-exporter
     spec:
+      initContainers:
+      - name: machine-id
+        image: alpine:3
+        command: ['/bin/sh', '-c']
+        args: ['echo systemd_machine_id{id=\"$(cat /host/root/etc/machine-id)\"} 1 > /var/lib/node_exporter/machine_id.prom']
+        volumeMounts:
+        - name: textfile-collector
+          mountPath: /var/lib/node_exporter
+        - name: root
+          mountPath: /host/root
+          readOnly: true
       containers:
       - args:
         - --web.listen-address=127.0.0.1:9100
@@ -34,6 +45,8 @@ spec:
             cpu: 102m
             memory: 180Mi
         volumeMounts:
+        - mountPath: /var/lib/node_exporter
+          name: textfile-collector
         - mountPath: /host/proc
           name: proc
         - mountPath: /host/sys
@@ -76,6 +89,8 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - emptyDir: {}
+        name: textfile-collector
       - hostPath:
           path: /proc
         name: proc

--- a/katalog/node-exporter/deploy.yml
+++ b/katalog/node-exporter/deploy.yml
@@ -23,6 +23,7 @@ spec:
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        - --collector.textfile.directory=/var/lib/node_exporter
         image: quay.io/prometheus/node-exporter:v0.18.1
         name: node-exporter
         resources:

--- a/katalog/prometheus-operated/rules.yml
+++ b/katalog/prometheus-operated/rules.yml
@@ -409,6 +409,15 @@ spec:
       for: 1h
       labels:
         severity: warning
+    - alert: NodeMachineIDCollision
+      annotations:
+        description: 'Machine ID {{ $labels.id }} is duplicated among {{ $value }} nodes.'
+        summary: Machine ID collision.
+      expr: |
+        count by (id) (systemd_machine_id) > 1
+      for: 5m
+      labels:
+        severity: critical
   - name: kubernetes-apps
     rules:
     - alert: KubePodCrashLooping

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -5,8 +5,8 @@ load ./helper
 @test "Applying prometheus-operator, cert-manager CRDs and cert-manager" {
   info
   kubectl apply -f katalog/prometheus-operator/crd-servicemonitor.yml
-  kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-ingress/master/katalog/cert-manager/cert-manager-controller/crd.yml
-  apply "github.com/sighupio/fury-kubernetes-ingress.git//katalog/cert-manager/?ref=v1.4.1"
+  kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-ingress/v1.5.0/katalog/cert-manager/cert-manager-controller/crd.yml
+  apply "github.com/sighupio/fury-kubernetes-ingress.git//katalog/cert-manager/?ref=v1.5.0"
 }
 
 @test "Deploy prometheus-operator" {


### PR DESCRIPTION
The aim of this PR is to add a metric to keep track of machine ID and an alert that would fire whenever two or more nodes share the same machine ID.

Summary of changes:
  - enabled node_exporter's textfile collector
  - added `systemd_machine_id` metric
  - added `NodeMachineIDCollision` alert.

Closes: sighupio/fury-kubernetes-monitoring#21