### PR TITLE
Update compatibility matrix accordingly to kube-state-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Version: **2.0.0**
 - [kubeadm-sm](katalog/kubeadm-sm): Service Monitors, Prometheus rules and
   alerts for Kubernetes components of unmanaged/on-promise clusters.
 - [kube-state-metrics](katalog/kube-state-metrics): Service Monitor for
-  Kubernetes objects such as Deployments, Nodes and Pods. Version: **1.9.4**
+  Kubernetes objects such as Deployments, Nodes and Pods. Version: **1.9.5**
 - [node-exporter](katalog/node-exporter): Service Monitor for hardware and OS
   metrics exposed by \*NIX kernels. Version: **0.18.1**
 - [metrics-server](katalog/metrics-server): Resource metrics collection from

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ specific dependencies please visit the single package's documentation:
 - :warning: Has issues
 - :x: Incompatible
 
+### Warning
+
+- [kube-state-metrics](katalog/kube-state-metrics) is not able to scrape
+  `ValidatingWebhookConfiguration` in Kubernetes < 1.16.X.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ specific dependencies please visit the single package's documentation:
 | v1.1.0                              | :white_check_mark: | :white_check_mark: | :x:                |
 | v1.2.0                              | :white_check_mark: | :white_check_mark: | :x:                |
 | v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.4.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.4.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.5.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.6.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.6.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.4.0                              | :warning:          | :warning:          | :white_check_mark: |
+| v1.4.1                              | :warning:          | :warning:          | :white_check_mark: |
+| v1.5.0                              | :warning:          | :warning:          | :white_check_mark: |
+| v1.6.0                              | :warning:          | :warning:          | :white_check_mark: |
+| v1.6.1                              | :warning:          | :warning:          | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -8,7 +8,7 @@ Changes between `1.3.0` and this release: `1.4.0`
   - alertmanager-operated from version v0.16.0 to version v0.20.0
   - grafana from version v5.3.4 to version v6.6.2
     - Added grafana dashboards
-  - kube-state-metrics update from v1.8.0 to version v1.9.4
+  - kube-state-metrics update from v1.8.0 to version v1.9.5
   - node-exporter update from v0.16.0 to version v0.18.1
     - scrape interval for node-exporter changed to '15s' from '30s'
     - cpu resource limit increase to '250m' from '102m'

--- a/katalog/kube-state-metrics/README.md
+++ b/katalog/kube-state-metrics/README.md
@@ -26,7 +26,7 @@ From kube-state-metrics
 
 ## Image repository and tag
 
-* kube-state-metrics image: `quay.io/coreos/kube-state-metrics:v1.9.4`
+* kube-state-metrics image: `quay.io/coreos/kube-state-metrics:v1.9.5`
 * kube-state-metrics repository:
   https://github.com/kubernetes/kube-state-metrics
 


### PR DESCRIPTION
Closes #32.

Summary of changes:
- fixed kube-state-metrics version in READMEs and release notes
- updated compatibility matrix