### PR TITLE
Fix cert-manager annotion in metrics-sever APIService

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,7 +1,0 @@
-# Release notes
-
-## Changelog
-
-Changes between `1.7.0` and this release: `TBD`
-
-- Added Gatekeeper dashboard to Grafana

--- a/docs/releases/v1.7.1.md
+++ b/docs/releases/v1.7.1.md
@@ -1,0 +1,8 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.7.0` and this release: `1.7.1`
+
+- Added Gatekeeper dashboard to Grafana
+- FIX: Move cert-manager annotation to the current one

--- a/katalog/metrics-server/apiservice.yml
+++ b/katalog/metrics-server/apiservice.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: metrics-server
   annotations:
-    certmanager.k8s.io/inject-ca-from: "kube-system/metrics-server-tls"
+    cert-manager.io/inject-ca-from: "kube-system/metrics-server-tls"
 spec:
   group: metrics.k8s.io
   groupPriorityMinimum: 100


### PR DESCRIPTION
Fixed cert-manager annotation in metrics-server APIService in order for the CA to be correctly injected.