### PR TITLE
Remove duplicate alerts from kubeadm-sm

### DIFF
--- a/katalog/kubeadm-sm/rules.yml
+++ b/katalog/kubeadm-sm/rules.yml
@@ -244,25 +244,3 @@ spec:
       labels:
         quantile: "0.5"
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
-  - name: kubernetes-system-scheduler
-    rules:
-    - alert: KubeSchedulerDown
-      annotations:
-        message: KubeScheduler has disappeared from Prometheus target discovery.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown
-      expr: |
-        absent(up{job="kube-scheduler"} == 1)
-      for: 15m
-      labels:
-        severity: critical
-  - name: kubernetes-system-controller-manager
-    rules:
-    - alert: KubeControllerManagerDown
-      annotations:
-        message: KubeControllerManager has disappeared from Prometheus target discovery.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown
-      expr: |
-        absent(up{job="kube-controller-manager"} == 1)
-      for: 15m
-      labels:
-        severity: critical


### PR DESCRIPTION
The aim of this PR is to clean-up some alerts that were mistakenly duplicate in the 1.4.0 release.