### PR TITLE
Remove CPUThrottlingHigh alert from prometheus-operated

### DIFF
--- a/katalog/prometheus-operated/rules.yml
+++ b/katalog/prometheus-operated/rules.yml
@@ -678,20 +678,6 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: CPUThrottlingHigh
-      annotations:
-        message: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-          {{ $labels.namespace }} for container {{ $labels.container }} in pod {{
-          $labels.pod }}.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh
-      expr: |
-        sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
-          /
-        sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
-          > ( 25 / 100 )
-      for: 15m
-      labels:
-        severity: warning
   - name: kubernetes-storage
     rules:
     - alert: KubePersistentVolumeUsageCritical


### PR DESCRIPTION
This alert is flooding us on basically every cluster without any added benefit, therefore I'm removing it.

Refs:
- sighupio/fury-kubernetes-monitoring#36