### PR TITLE
Hotfixing grafana dashboard management

### DIFF
--- a/docs/releases/v1.9.1.md
+++ b/docs/releases/v1.9.1.md
@@ -1,0 +1,17 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.9.0` and this release: `1.9.1`
+
+- Changing grafana dashboard generation
+
+## Update procedure from v1.9.0
+
+Go in the `monitoring` namespace, and delete all the grafana configmap dashboards with:
+
+```bash
+kubectl delete cm -l grafana-sighup-dashboard=default
+```
+
+Then, apply the new version

--- a/katalog/grafana/dashboards/kustomization.yaml
+++ b/katalog/grafana/dashboards/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  disableNameSuffixHash: true
 
 configMapGenerator:
   - name: grafana-dashboard-definitions-k8s


### PR DESCRIPTION
Hello, 

i tried the v1.9.0 version and i found a bug. If we change some dashboard, we will create a new configmap with a new suffix, and the grafana sidecar dashboard reloader is not able to manage this use case. 

To fix this, i added `disableNameSuffixHash: true` on the grafana configmap dashboard generation