### PR TITLE
Switch metrics scraping for controller-manager and scheduler to secure port

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ specific dependencies please visit the single package's documentation:
 | v1.10.0                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
 | v1.10.1                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
 | v1.10.2                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
+| v1.10.3                             |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :warning:      |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.10.3.md
+++ b/docs/releases/v1.10.3.md
@@ -1,0 +1,18 @@
+# Monitoring Core Module version 1.10.3
+
+`kubeadm` versions starting from `1.17` are not exposing `kube-controller-manager` nor `kube-scheduler` metrics
+over the insecure port *(respectively TCP/10252 and TCP/10251)*.
+This makes the current `ServiceMonitor` configuration unable to properly scrape these targets.
+
+## Changelog
+
+- FIX #51: `kubeadm-sm` package to proper configure `serviceMonitors` to solve `kubeadm` +1.17 versions.
+
+## Upgrade path
+
+To upgrade this core module from `v1.10.2` to `v1.10.3`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+kustomize build katalog/kubeadm-sm | kubectl apply -f -
+```

--- a/katalog/configs/kubeadm/service-monitors/controller-manager.yml
+++ b/katalog/configs/kubeadm/service-monitors/controller-manager.yml
@@ -10,7 +10,8 @@ metadata:
   name: kube-controller-manager
 spec:
   endpoints:
-  - interval: 30s
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
     metricRelabelings:
     - action: drop
       regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
@@ -49,6 +50,9 @@ spec:
       sourceLabels:
       - __name__
     port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:
@@ -66,7 +70,7 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 10252
+    port: 10257
     protocol: TCP
   selector:
     component: kube-controller-manager

--- a/katalog/configs/kubeadm/service-monitors/scheduler.yml
+++ b/katalog/configs/kubeadm/service-monitors/scheduler.yml
@@ -10,8 +10,12 @@ metadata:
   name: kube-scheduler
 spec:
   endpoints:
-  - interval: 30s
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
     port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:
@@ -29,7 +33,7 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 10251
+    port: 10259
     protocol: TCP
   selector:
     component: kube-scheduler


### PR DESCRIPTION
The aim of this PR is to switch controller-manager and scheduler ServiceMonitors to secure port in order for scraping to work correctly on Kubernetes 1.17+ kubeadm clusters where the insecure metrics serving was disabled.

The `insecureSkipVerify: true` is needed since both components rely on a self-signed server certificate to encrypt the communication while relying on Kubernetes RBAC to enforce authorization to the `/metrics` endpoint (which is covered by `bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token`)

Refs:
  - https://github.com/sighupio/fury-kubernetes-monitoring/issues/51