### PR TITLE
Modify the cluster cert expiration alerts to fire earlier

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,20 @@
+# Monitoring Core Module version TBD
+
+SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
+With the Kubernetes 1.20 release, it became the perfect time to start testing this module against this Kubernetes
+release.
+
+Continue reading the [Changelog](#changelog) to discover them:
+
+## Changelog
+
+- Modify the alerts that track expiration of cluster certificates to fire within 30/7 days of expiration instead of 7/1 days. (kubeadm-k8s-rules, prometheus-k8s-rules)
+
+
+## Upgrade path
+
+To upgrade to this core module from `v1.11.0`, it should be sufficient to simply apply the `kustomize` project.
+
+```bash
+kustomize build | kubectl apply -f -
+```

--- a/katalog/configs/kubeadm/README.md
+++ b/katalog/configs/kubeadm/README.md
@@ -56,8 +56,8 @@ The followings alerts are already defined for this package.
 |------|-------------|----------|:-----:|
 | KubeControllerManagerDown | This alert fires if Prometheus target discovery was not able to reach the kube-controller-manager in the last 15 minutes. | critical | 15m |
 | KubeSchedulerDown | This alert fires if Prometheus target discovery was not able to reach the kube-scheduler in the last 15 minutes. | critical | 15m |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 7 days. | warning |  |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 1 day. | critical |  |
+| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 30 days. | warning |  |
+| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 7 days. | critical |  |
 
 ### coredns
 

--- a/katalog/configs/kubeadm/rules.yml
+++ b/katalog/configs/kubeadm/rules.yml
@@ -36,20 +36,20 @@ spec:
         severity: critical
     - alert: KubeClientCertificateExpiration
       annotations:
+        description: A client certificate used to authenticate to the apiserver is expiring in less than 30.0 days.
+        runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubeclientcertificateexpiration
+        summary: Client certificate is about to expire.
+      expr: |
+        apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 2592000
+      labels:
+        severity: warning
+    - alert: KubeClientCertificateExpiration
+      annotations:
         description: A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubeclientcertificateexpiration
         summary: Client certificate is about to expire.
       expr: |
         apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
-      labels:
-        severity: warning
-    - alert: KubeClientCertificateExpiration
-      annotations:
-        description: A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.
-        runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubeclientcertificateexpiration
-        summary: Client certificate is about to expire.
-      expr: |
-        apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
       labels:
         severity: critical
   - name: etcd3

--- a/katalog/kubeadm-sm/README.md
+++ b/katalog/kubeadm-sm/README.md
@@ -56,8 +56,8 @@ The followings alerts are already defined for this package.
 |------|-------------|----------|:-----:|
 | KubeControllerManagerDown | This alert fires if Prometheus target discovery was not able to reach the kube-controller-manager in the last 15 minutes. | critical | 15m |
 | KubeSchedulerDown | This alert fires if Prometheus target discovery was not able to reach the kube-scheduler in the last 15 minutes. | critical | 15m |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 7 days. | warning |  |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 1 day. | critical |  |
+| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 30 days. | warning |  |
+| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 7 days. | critical |  |
 
 ### coredns
 

--- a/katalog/prometheus-operated/rules.yml
+++ b/katalog/prometheus-operated/rules.yml
@@ -1756,7 +1756,7 @@ spec:
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubeletclientcertificateexpiration
         summary: Kubelet client certificate is about to expire.
       expr: |
-        kubelet_certificate_manager_client_ttl_seconds < 604800
+        kubelet_certificate_manager_client_ttl_seconds < 2592000
       labels:
         severity: warning
     - alert: KubeletClientCertificateExpiration
@@ -1765,7 +1765,7 @@ spec:
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubeletclientcertificateexpiration
         summary: Kubelet client certificate is about to expire.
       expr: |
-        kubelet_certificate_manager_client_ttl_seconds < 86400
+        kubelet_certificate_manager_client_ttl_seconds < 604800
       labels:
         severity: critical
     - alert: KubeletServerCertificateExpiration
@@ -1774,7 +1774,7 @@ spec:
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubeletservercertificateexpiration
         summary: Kubelet server certificate is about to expire.
       expr: |
-        kubelet_certificate_manager_server_ttl_seconds < 604800
+        kubelet_certificate_manager_server_ttl_seconds < 2592000
       labels:
         severity: warning
     - alert: KubeletServerCertificateExpiration
@@ -1783,7 +1783,7 @@ spec:
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubeletservercertificateexpiration
         summary: Kubelet server certificate is about to expire.
       expr: |
-        kubelet_certificate_manager_server_ttl_seconds < 86400
+        kubelet_certificate_manager_server_ttl_seconds < 604800
       labels:
         severity: critical
     - alert: KubeletClientCertificateRenewalErrors


### PR DESCRIPTION
We want to avoid getting into situations where we have too little time to renew certs on the clusters, because we were notified very late.

The certs are valid for 1 year, so 1 month expiration warning is reasonable.
Likewise, 7 day alert of critical severity is also appropriate.

Hopefully, the MR covers all relevant alerts, and updates all relevant documentation.