### PR TITLE
Fixing the GID in kube-rbac-proxy

### DIFF
--- a/katalog/kube-proxy-metrics/deploy.yml
+++ b/katalog/kube-proxy-metrics/deploy.yml
@@ -27,6 +27,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+        runAsGroup: 65534
       hostNetwork: true
       containers:
       - name: kube-proxy-metrics


### PR DESCRIPTION
Fixes the following permission error:
```
"Error: failed to start container "kube-rbac-proxy": Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "chdir to cwd ("/home/nonroot") set in config.json failed: permission denied": unknown"
```