### PR TITLE
Remove experimental.enable-index-cache-postings-compression flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ specific dependencies please visit the single package's documentation:
 | v1.12.0                             |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 | v1.12.1                             |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 | v1.12.2                             |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
+| v1.12.3                             |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues
@@ -122,19 +123,19 @@ and Grafana using the following `Furyfile.yml` :
 ```yaml
 bases:
     - name: monitoring/prometheus-operator
-      version: v1.12.2
+      version: v1.12.3
     - name: monitoring/prometheus-operated
-      version: v1.12.2
+      version: v1.12.3
     - name: monitoring/alertmanager-operated
-      version: v1.12.2
+      version: v1.12.3
     - name: monitoring/node-exporter
-      version: v1.12.2
+      version: v1.12.3
     - name: monitoring/kube-state-metrics
-      version: v1.12.2
+      version: v1.12.3
     - name: monitoring/grafana
-      version: v1.12.2
+      version: v1.12.3
     - name: monitoring/goldpinger
-      version: v1.12.2
+      version: v1.12.3
 ```
 
 and execute

--- a/docs/releases/v1.12.3.md
+++ b/docs/releases/v1.12.3.md
@@ -1,0 +1,18 @@
+# Monitoring Core Module version v1.12.3
+
+This patch includes hotfix in `thanos/thanos-with-store` package.
+
+## Changelog
+
+- Remove unsupported flag `--experimental.enable-index-cache-postings-compression` (behaviour is now the default)
+
+## Upgrade path
+
+To upgrade this core module from `v1.12.2` to `v1.12.3`:
+
+1. Download the new module version
+2. Build and apply the `kustomize` project:
+
+```bash
+kustomize build katalog/thanos/thanos-with-store | kubectl apply -f -
+```

--- a/katalog/thanos/thanos-components/thanos-store/thanos-store.yaml
+++ b/katalog/thanos/thanos-components/thanos-store/thanos-store.yaml
@@ -57,7 +57,6 @@ spec:
             - --objstore.config-file=/etc/thanos/config.yaml
             - --index-cache-size=4GB
             - --chunk-pool-size=6GB
-            - --experimental.enable-index-cache-postings-compression
           ports:
             - name: http
               containerPort: 10902


### PR DESCRIPTION
Hello team 👋 ,

The flag `--experimental.enable-index-cache-postings-compression` was removed from Thanos v0.17.0, and its behaviour is now the default. We need to remove this flag otherwise Thanos will not start.

Thanos Changelog: https://github.com/thanos-io/thanos/blob/main/CHANGELOG.md#changed-8
Thanos PR: https://github.com/thanos-io/thanos/pull/3452

