### PR TITLE
refactor: edit alertmanager notification default behaviour

### DIFF
--- a/katalog/alertmanager-operated/alertmanager.yaml
+++ b/katalog/alertmanager-operated/alertmanager.yaml
@@ -8,20 +8,23 @@ global:
   smtp_from: "support@example.org"
   smtp_require_tls: false
 route:
-  group_by: ['alertname', 'cluster', 'service', 'job']
+  group_by: ['...']
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 1h
   receiver: 'sighup-team'
   routes:
-  - match:
+
+  - receiver: healthchecks
+    match:
       alertname: DeadMansSwitch
     group_wait: 30s
     group_interval: 1m
     repeat_interval: 1m
-    receiver: healthchecks
-  - match:
-    receiver: 'sighup-team'
+    
+  - receiver: 'sighup-team'
+    match:
+    
 receivers:
   - name: 'sighup-team'
     slack_configs:


### PR DESCRIPTION
1. this should let slack send different notification for different alert
2. as per [documentation](https://www.prometheus.io/docs/alerting/latest/configuration/), routes should be listed by receiver and not match

the first edit is to the group_by because it will check every label in Prometheus in order to aggregate, if it can't find any of them or only one, it will aggregate for it, so, if you have two alerts with the same `alertname` but different `namespace`, those two alerts will come in the same notification, and the second one will be hidden under "show more"

```
 Alert: KubePodNotReady - warning
 Description: Pod namespace-a/pod-a has been in a non-ready state for longer than 15 minutes.
 Details:
 • alertname: KubePodNotReady
 • k8s_cluster: supercluster
 • namespace: namespace-a
 • pod: pod-a
 • prometheus: monitoring/k8s
 • severity: warning
 Alert: KubePodNotReady - warning
 Description: Pod namespace-b/pod-b has been in a non-ready state for longer than 15 minutes.
 Details:
 • alertname: KubePodNotReady
 • k8s_cluster: supercluster
 • namespace: namespace-b
 • pod: pod-b
 • prometheus: monitoring/k8s
 • severity: warning
```

The second point is to elude some pain that can occur if you have to direct the same alert to a different group. You can't set different receivers in the same set, as the documentation said, that's why it's listed at that level.
the configuration posted here will make an alert for the pod-a in the namespace-b follow correctly all the different level, sending a slack to `slack-alert-evergreen` and `slack-alert-namespace-a` but no `alert-team`

     - receiver: 'slack-alert-evergreen'
       continue: true
       match_re:
         pod: pod-a
         namespace: "^(namespace-a|namespace-b|namespace-c)"
     - receiver: 'slack-alert-namespace-a'
       match_re:
         namespace: namespace-a
     - receiver: 'alert-team'
       match_re:
         alertname: '.*'
