### PR TITLE
Mark 1.14.0 as warning in compatibility matrix

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -23,7 +23,7 @@
 | v1.12.1                             |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |                    |           |
 | v1.12.2                             |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |                    |           |
 | v1.13.0                             |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |           |
-| v1.14.0                             |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
+| v1.14.0                             |                    |                    |                    |                    |                    |                    | :warning: | :warning: | :warning: | :warning: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues
@@ -39,7 +39,6 @@ because it is not officially supported by [SIGHUP](https://sighup.io).
 because it is not officially supported by [SIGHUP](https://sighup.io).
 - :warning: : module version: `v1.13.0` and Kubernetes Version: `1.22.x`. It works as expected. Marked as warning
 because it is not officially supported by [SIGHUP](https://sighup.io).
-- :warning: : module version: `v1.14.0` and Kubernetes Version: `1.23.x`. It works as expected. Marked as warning
-because it is not officially supported by [SIGHUP](https://sighup.io).
+- :warning: : module version: `v1.14.0` has a known issue where Prometheus Service is not working as expected. See [Issue #83](https://github.com/sighupio/fury-kubernetes-monitoring/issues/83).
 
 


### PR DESCRIPTION
v1.14.0 has a known issue with prometheus since the adoption of the custom labels.
See:
https://github.com/sighupio/fury-kubernetes-monitoring/issues/83