### PR TITLE
fix(prometheus-operated): fixes retentionSize unit

### DIFF
--- a/katalog/prometheus-operated/deploy.yml
+++ b/katalog/prometheus-operated/deploy.yml
@@ -31,7 +31,7 @@ spec:
       cpu: 2000m
       memory: 2Gi
   retention: 30d
-  retentionSize: 120G
+  retentionSize: 120GB
   ruleSelector: {}
   ruleNamespaceSelector: {}
   securityContext:


### PR DESCRIPTION
The change introduced in #95 adding the `retentionSize` parameter to prometheus-operated had a bug in the value.

The operator logged the following error:

```log
level=error ts=2022-07-22T10:20:22.090021694Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="Sync \"monitoring/k8s\" failed: creating config failed: generating config failed: invalid retentionSize value specified: units: unknown unit G in 120G"
```

The unit was wrong, it was missing a `B`.

This PR fixes the issue.