### PR TITLE
CI: rename from `master` to `main` and add `release-v*` branches to triggers

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -204,7 +204,8 @@ node:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v*
       - refs/tags/**
 
 steps:
@@ -303,7 +304,8 @@ node:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v*
       - refs/tags/**
 
 steps:
@@ -402,7 +404,8 @@ node:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v*
       - refs/tags/**
 
 steps:
@@ -501,7 +504,8 @@ node:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v*
       - refs/tags/**
 
 steps:


### PR DESCRIPTION
As per PR title.

Please note: unless we implement branch protection, anyone creating a `release-v*` branch will trigger e2e tests so maybe we should split this PR in two.