### PR TITLE
fix(configs/kubeadm): fix SM port name

### DIFF
--- a/katalog/configs/kubeadm/service-monitors/controller-manager.yml
+++ b/katalog/configs/kubeadm/service-monitors/controller-manager.yml
@@ -51,7 +51,7 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
-    port: metrics
+    port: https-metrics
     scheme: https
     tlsConfig:
       insecureSkipVerify: true

--- a/katalog/configs/kubeadm/service-monitors/controller-manager.yml
+++ b/katalog/configs/kubeadm/service-monitors/controller-manager.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -51,7 +51,7 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
-    port: https-metrics
+    port: metrics
     scheme: https
     tlsConfig:
       insecureSkipVerify: true

--- a/katalog/configs/kubeadm/service-monitors/scheduler.yml
+++ b/katalog/configs/kubeadm/service-monitors/scheduler.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -14,7 +14,7 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
-    port: https-metrics
+    port: metrics
     scheme: https
     tlsConfig:
       insecureSkipVerify: true

--- a/katalog/configs/kubeadm/service-monitors/scheduler.yml
+++ b/katalog/configs/kubeadm/service-monitors/scheduler.yml
@@ -14,7 +14,7 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
-    port: metrics
+    port: https-metrics
     scheme: https
     tlsConfig:
       insecureSkipVerify: true

--- a/katalog/configs/kubeadm/services/controller-manager.yml
+++ b/katalog/configs/kubeadm/services/controller-manager.yml
@@ -11,7 +11,7 @@ metadata:
   name: kube-controller-manager
 spec:
   ports:
-  - name: metrics
+  - name: https-metrics
     port: 10257
     protocol: TCP
   selector:

--- a/katalog/configs/kubeadm/services/scheduler.yml
+++ b/katalog/configs/kubeadm/services/scheduler.yml
@@ -11,7 +11,7 @@ metadata:
   name: kube-scheduler
 spec:
   ports:
-  - name: metrics
+  - name: https-metrics
     port: 10259
     protocol: TCP
   selector:


### PR DESCRIPTION
Fix port name for kube-controller-manager and kube-scheduler in ServiceMonitor defintion.
Port name was different in the Service defintition.

Fixes #109