### PR TITLE
docs(releases): improve 2.0.0 release notes

### DIFF
--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -46,7 +46,7 @@ This release includes upgrades for the components in the module to its latest st
 
 - Since the release ships changes to some immutable fields, the upgrade process will involve the deletion and recreation of some resources.
 - Notice that all the `kubectl apply` commands make use of the `--server-side` flag, this is needed because some objects are very large and the annotations introduced by the client side apply go beyond the maximum size.
-- AlertManager's configuration has been changed. You'll need to create 3 new secrets with the notification endpoints for it to work properly.
+- Alertmanager configuration has been changed. You'll need to create 3 new secrets with the notification endpoints for it to work properly.
 
 ### Process
 

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -71,7 +71,7 @@ kustomize build katalog/prometheus-operated | kubectl apply -f - --server-side
 
 - `alertmanager-operated`
 
-Alert Manager now reads the notification enpoint for Slack and Healthchecks.io from secrets, instead of having it embedded in the configuration.
+Alertmanager now reads the notification enpoint for Slack and Healthchecks.io from secrets, instead of having it embedded in the configuration.
 
 You will need to create these secrets before applying the new version:
 

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -2,12 +2,12 @@
 
 Welcome to the latest release of the `monitoring` core module of the [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution), maintained by team SIGHUP.
 
-This release includes upgrades the components in the module to its latest stable releases introduces two new components and deprecates other two, it also introduces support for Kubernetes `v1.24.0`. See more details in the [Features](#features-) section.
+This release includes upgrades for the components in the module to its latest stable releases, introduces two new components and deprecates other two, it also introduces support for Kubernetes `v1.24.0`. See more details in the [Features](#features-) section.
 
 ## Component Images 🚢
 
 | Component             | Supported Version                                                                            | Previous Version |
-|-----------------------|----------------------------------------------------------------------------------------------|------------------|
+| --------------------- | -------------------------------------------------------------------------------------------- | ---------------- |
 | `alertmanager`        | [`v0.24.0`](https://github.com/prometheus/alertmanager/releases/tag/v0.24.0)                 | `v0.23.0`        |
 | `blackbox-exporter`   | [`v0.21.0`](https://github.com/prometheus/blackbox_exporter/releases/tag/v0.21.0)            | `New Package`    |
 | `grafana`             | [`v8.5.5`](https://github.com/grafana/grafana/releases/tag/v8.5.5)                           | `v8.3.3`         |
@@ -22,36 +22,21 @@ This release includes upgrades the components in the module to its latest stable
 | `thanos`              | [`v0.24.0`](https://github.com/thanos-io/thanos/releases/tag/v0.24.0)                        | `No Update`      |
 | `x509-exporter`       | [`v3.2.0`](https://github.com/enix/x509-certificate-exporter/releases/tag/v3.2.0)            | `2.12.1`         |
 
-> Please refer the individual release notes to get a detailed info on the
-> releases.
-
+> Please refer the individual release notes to get a detailed info on the releases.
 
 ## Breaking Changes 💔
 
-- This is a new major release so it involves the deletion and recreation of some
-  resources. More details in the [Update Guide](#update-guide-) section.
-- Since the `Prometheus` CRD is too big, you will need to use `kubectl apply
-  --server-side` instead of plain `kubectl apply` to deploy the module. See
-  prometheus-operator/prometheus-operator#4439 and kubernetes/kubernetes#82292.
-- [`metrics-server`](https://github.com/kubernetes-sigs/metrics-server) is not
-  supported anymore by this module.
-- [`goldpinger`](https://github.com/bloomberg/goldpinger) is not supported
-  anymore by this module.
+- This is a new major release so it involves the deletion and recreation of some resources. More details in the [Update Guide](#update-guide-) section.
+- Since the `Prometheus` CRD is too big, you will need to use `kubectl apply --server-side` instead of plain `kubectl apply` to deploy the module. See prometheus-operator/prometheus-operator#4439 and kubernetes/kubernetes#82292.
+- [`metrics-server`](https://github.com/kubernetes-sigs/metrics-server) is not supported anymore by this module.
+- [`goldpinger`](https://github.com/bloomberg/goldpinger) is not supported anymore by this module.
 
 ## Features 💥
 
-- Sync module with release
-  [`0.11.0`](https://github.com/prometheus-operator/kube-prometheus/releases/tag/v0.11.0) of the upstream project kube-prometheus.
-- Replace [`metrics-server`](https://github.com/kubernetes-sigs/metrics-server)
-  with
-  [`prometheus-adapter`](https://github.com/kubernetes-sigs/prometheus-adapter)
-  thus removing the dependency on the
-  [`cert-manager`](https://github.com/sighupio/fury-kubernetes-ingress/tree/master/katalog/cert-manager)
-  package and enabling workload autoscaling on custom metrics.
-- Removed [`goldpinger`](https://github.com/bloomberg/goldpinger) that was
-  creating high-cardinality metrics in big clusters.
-- Added a default configuration con Alertmanager through the usage of the new
-  `AlertmanagerConfig` CRD.
+- Sync module with release [`0.11.0`](https://github.com/prometheus-operator/kube-prometheus/releases/tag/v0.11.0) of the upstream project kube-prometheus.
+- Replace [`metrics-server`](https://github.com/kubernetes-sigs/metrics-server) with [`prometheus-adapter`](https://github.com/kubernetes-sigs/prometheus-adapter) thus removing the dependency on the [`cert-manager`](https://github.com/sighupio/fury-kubernetes-ingress/tree/master/katalog/cert-manager) package and enabling workload autoscaling based on custom metrics.
+- Removed [`goldpinger`](https://github.com/bloomberg/goldpinger) that was creating high-cardinality metrics in big clusters.
+- Added a default configuration con Alertmanager through the usage of the new `AlertmanagerConfig` CRD.
 - Added `blackbox-exporter` to allow blackbox probing via the `Probe` CRD.
 - Added support for Kubernetes v1.24.x
 
@@ -59,21 +44,23 @@ This release includes upgrades the components in the module to its latest stable
 
 ### Warnings
 
-- Since the release ships changes to some immutable fields, the upgrade process
-  will involve the deletion and recreation of some resources.
+- Since the release ships changes to some immutable fields, the upgrade process will involve the deletion and recreation of some resources.
 - Notice that all the `kubectl apply` commands make use of the `--server-side` flag, this is needed because some objects are very large and the annotations introduced by the client side apply go beyond the maximum size.
+- AlertManager's configuration has been changed. You'll need to create 3 new secrets with the notification endpoints for it to work properly.
 
 ### Process
 
 To upgrade this core module from `v1.14.x` to `v2.0.0`, execute the following:
 
 - `prometheus-operator`
+
 ```shell
 kubectl delete deployments.apps prometheus-operator -n monitoring
 kustomize build katalog/promethes-operator | kubectl apply -f - --server-side
 ```
 
 - `prometheus-operated`
+
 ```shell
 kubectl delete poddisruptionbudgets.policy prometheus-k8s -n monitoring
 kubectl delete clusterrolebinding.rbac.authorization.k8s.io prometheus-k8s-scrape
@@ -83,17 +70,39 @@ kustomize build katalog/prometheus-operated | kubectl apply -f - --server-side
 ```
 
 - `alertmanager-operated`
+
+Alert Manager now reads the notification enpoint for Slack and Healthchecks.io from secrets, instead of having it embedded in the configuration.
+
+You will need to create these secrets before applying the new version:
+
+> 💡 the next commands are provided as example, we recommend to keep the secrets generation together with the rest of your Infrastructure as Code files.
+
+```shell
+$ kubectl create secret generic infra-slack-webhook -n monitoring --from-literal url="<http(s)://your endpoint URL>"
+secret/infra-slack-webhook created
+
+$ kubectl create secret generic healthchecks-webhook -n monitoring --from-literal url="<http(s)://your endpoint URL>"
+secret/healthchecks-webhook created
+
+$ kubectl create secret generic k8s-slack-webhook -n monitoring --from-literal url="<http(s)://your endpoint URL>"
+secret/k8s-slack-webhook created
+```
+
+Proceed with the upgrade:
+
 ```shell
 kubectl delete poddisruptionbudget.policy alertmanager-main -n monitoring
 kustomize build katalog/alertmanager-operated | kubectl apply -f - --server-side
 ```
 
 - `blackbox-exporter`
+
 ```shell
 kustomize build katalog/blackbox-exporter | kubectl apply -f - --server-side
 ```
 
 - `goldpinger`
+
 ```shell
 kubectl delete servicemonitor.monitoring.coreos.com goldpinger -n monitoring
 kubectl delete service goldpinger -n monitoring
@@ -104,23 +113,27 @@ kubectl delete rolebinding.rbac.authorization.k8s.io goldpinger:cluster:view -n 
 ```
 
 - `grafana`
+
 ```shell
 kubectl delete deployments.apps grafana -n monitoring
 kustomize build katalog/grafana | kubectl apply -f - --server-side
 ```
 
 - `kube-proxy-metrics`
+
 ```shell
 kustomize build katalog/kube-proxy-metrics | kubectl apply -f - --server-side --force-conflicts
 ```
 
 - `kube-state-metrics`
+
 ```shell
 kubectl delete deployments.apps kube-state-metrics -n monitoring
 kustomize build katalog/kube-state-metrics | kubectl apply -f - --server-side
 ```
 
 - `metrics-server`
+
 ```shell
 kubectl delete apiservice.apiregistration.k8s.io v1beta1.metrics.k8s.io
 kubectl delete service metrics-server -n kube-system
@@ -135,20 +148,24 @@ kubectl delete certificate.cert-manager.io metrics-server-tls -n kube-system
 kubectl delete certificate.cert-manager.io metrics-server-ca -n kube-system
 kubectl delete issuer.cert-manager.io metrics-server-ca -n kube-system
 kubectl delete issuer.cert-manager.io metrics-server-selfsign -n kube-system
+kubectl delete secret metrics-server-ca metrics-server-tls -n kube-system
 ```
 
 - `node-exporter`
+
 ```shell
 kubectl delete daemonsets.apps node-exporter -n monitoring
 kustomize build katalog/node-exporter | kubectl apply -f - --server-side
 ```
 
 - `prometheus-adapter`
+
 ```shell
 kustomize build katalog/prometheus-adapter | kubectl apply -f - --server-side
 ```
 
 - `x509-exporter`
+
 ```shell
 kubectl delete serviceaccount x509-certificate-exporter-node -n monitoring
 kubectl delete clusterrole.rbac.authorization.k8s.io x509-certificate-exporter-node


### PR DESCRIPTION
- Fix some format issues
- Fix some linting issues
- Add command to delete metrics-server TLS secrets, otherwise cert-manager complains
- Add instructions about the new secrets needed for alertmanager's configuration

After the PR has been merged, I'll update also on GitHub the release.