### PR TITLE
fix(node-exporter): add GOMAXPROCS=1

### DIFF
--- a/katalog/node-exporter/MAINTENANCE.md
+++ b/katalog/node-exporter/MAINTENANCE.md
@@ -19,7 +19,7 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
 ## Customizations
 
-We added the `GOMAXPROCS=1` environment variable to limit the go rutines to 1 processor because node-exporter was getting throttled hard by Kubernetes when using all the host CPUs. The patch is done in the `kustomization.yaml` file.
+We added the `GOMAXPROCS=1` environment variable to limit the goroutines to 1 processor because node-exporter was getting hard throttled by Kubernetes when using all the host CPUs. The patch is done in the `kustomization.yaml` file.
 
 This change will also be included in upstream later and then can be deleted. See:
 

--- a/katalog/node-exporter/MAINTENANCE.md
+++ b/katalog/node-exporter/MAINTENANCE.md
@@ -16,3 +16,12 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
+
+## Customizations
+
+We added the `GOMAXPROCS=1` environment variable to limit the go rutines to 1 processor because node-exporter was getting throttled hard by Kubernetes when using all the host CPUs.
+
+This change will also be included in upstream later and then can be deleted. See:
+
+- <https://github.com/sighupio/fury-kubernetes-monitoring/issues/106>
+- <https://github.com/prometheus/node_exporter/pull/2530>

--- a/katalog/node-exporter/MAINTENANCE.md
+++ b/katalog/node-exporter/MAINTENANCE.md
@@ -19,7 +19,7 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
 ## Customizations
 
-We added the `GOMAXPROCS=1` environment variable to limit the go rutines to 1 processor because node-exporter was getting throttled hard by Kubernetes when using all the host CPUs.
+We added the `GOMAXPROCS=1` environment variable to limit the go rutines to 1 processor because node-exporter was getting throttled hard by Kubernetes when using all the host CPUs. The patch is done in the `kustomization.yaml` file.
 
 This change will also be included in upstream later and then can be deleted. See:
 

--- a/katalog/node-exporter/daemonset.yaml
+++ b/katalog/node-exporter/daemonset.yaml
@@ -41,6 +41,9 @@ spec:
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
         image: quay.io/prometheus/node-exporter:v1.3.1
         name: node-exporter
+        env:
+          - name: "GOMAXPROCS"
+            value: "1"
         resources:
           limits:
             cpu: 250m

--- a/katalog/node-exporter/daemonset.yaml
+++ b/katalog/node-exporter/daemonset.yaml
@@ -41,9 +41,6 @@ spec:
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
         image: quay.io/prometheus/node-exporter:v1.3.1
         name: node-exporter
-        env:
-          - name: "GOMAXPROCS"
-            value: "1"
         resources:
           limits:
             cpu: 250m

--- a/katalog/node-exporter/kustomization.yaml
+++ b/katalog/node-exporter/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -20,30 +20,35 @@ images:
     newTag: v0.12.0
 
 patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: DaemonSet
-  metadata:
-    name: node-exporter
-    namespace: monitoring
-  spec:
-    template:
-      spec:
-        initContainers:
-          - name: machine-id
-            image: alpine
-            command: ['/bin/sh', '-c']
-            args: ['echo systemd_machine_id{id=\"$(cat /host/root/etc/machine-id)\"} 1 > /var/lib/node_exporter/machine_id.prom']
-            volumeMounts:
-              - name: textfile-collector
-                mountPath: /var/lib/node_exporter
-              - name: root
-                mountPath: /host/root
-                readOnly: true
-        volumes:
-        - name: textfile-collector
-          emptyDir:
-            medium: Memory
+  - |-
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: node-exporter
+      namespace: monitoring
+    spec:
+      template:
+        spec:
+          initContainers:
+            - name: machine-id
+              image: alpine
+              command: ['/bin/sh', '-c']
+              args: ['echo systemd_machine_id{id=\"$(cat /host/root/etc/machine-id)\"} 1 > /var/lib/node_exporter/machine_id.prom']
+              volumeMounts:
+                - name: textfile-collector
+                  mountPath: /var/lib/node_exporter
+                - name: root
+                  mountPath: /host/root
+                  readOnly: true
+          containers:
+            - name: node-exporter
+              env:
+                - name: "GOMAXPROCS"
+                  value: "1"
+          volumes:
+          - name: textfile-collector
+            emptyDir:
+              medium: Memory
 
 patchesJSON6902:
   - target:


### PR DESCRIPTION
set `GOMAXPROCS=1` to avoid CPU throttling in Kubernetes.

See prometheus/node_exporter#2530

Even keeping the resource limits the error hasn't repeated in +6h adding the env var.

Fixes #106
