### PR TITLE
fix: namespace in patch will end in no patch applied

### DIFF
--- a/katalog/prometheus-operated/kustomization.yaml
+++ b/katalog/prometheus-operated/kustomization.yaml
@@ -41,7 +41,6 @@ patchesJSON6902:
       version: v1
       kind: ClusterRole
       name: prometheus-k8s
-      namespace: monitoring
     patch: |-
       - op: add
         path: /rules/-


### PR DESCRIPTION
Hi everyone 👋 !
Together with @smerlos today we've discovered that the patch `patchesJSON6902` related to ClusterRole `prometheus-k8s` is not working (at least with kustomize version `4.5.x`: ```{Version:kustomize/v4.5.7 GitCommit:56d82a8378dfc8dc3b3b1085e5a6e67b82966bd7 BuildDate:2022-08-02T16:35:54Z GoOs:darwin GoArch:arm64}```), and won't be applied without any failure message or exit codes (kustomize is basically ignoring the patch without any message). 
A deployment without the patch will create a running instance of Prometheus (no CrashLoopBackOff) but it won't work because of missing permissions to several API  objects of Kubernetes.
The current branch removes the patch's namespace, which makes the patch back working.
Please let us know if there is any other information that is needed!
