### PR TITLE
Feat: update node exporter to the latest stable version and test it with k8s 1.25

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,7 +73,7 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.24.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.25.0
     environment:
       KUBERNETES_MANIFESTS: alertmanager-operated.yml
 
@@ -192,209 +192,6 @@ steps:
 #     when:
 #       event:
 #         - tag
-
----
-name: e2e-kubernetes-1.21
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  runner: internal
-
-trigger:
-  ref:
-    include:
-      - refs/heads/main
-      - refs/heads/release-v*
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.1
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [clone]
-    settings:
-      action: custom-cluster-121
-      cluster_version: '1.21.12'
-      local_kind_config_path: katalog/tests/kind-config.yml
-      pipeline_id: cluster-121
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.7.0_3.1.1_1.9.4_1.21.12_3.8.7_4.21.1
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-121
-      - bats -t katalog/tests/tests.sh
-      - bats -t katalog/tests/grafana-ldap.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.1
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-121
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: shared
-    temp: {}
-
----
-name: e2e-kubernetes-1.22
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  runner: internal
-
-trigger:
-  ref:
-    include:
-      - refs/heads/main
-      - refs/heads/release-v*
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.1
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [clone]
-    settings:
-      action: custom-cluster-122
-      cluster_version: '1.22.9'
-      local_kind_config_path: katalog/tests/kind-config.yml
-      pipeline_id: cluster-122
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.7.0_3.1.1_1.9.4_1.22.9_3.8.7_4.21.1
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [init]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-122
-      - bats -t katalog/tests/tests.sh
-      - bats -t katalog/tests/grafana-ldap.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.1
-    pull: always
-    depends_on: [e2e]
-    settings:
-      action: destroy
-      pipeline_id: cluster-122
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: shared
-    temp: {}
-
 ---
 name: e2e-kubernetes-1.23
 kind: pipeline
@@ -597,15 +394,115 @@ volumes:
   - name: shared
     temp: {}
 ---
+name: e2e-kubernetes-1.25
+kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  runner: internal
+
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/heads/release-v*
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [clone]
+    settings:
+      action: custom-cluster-125
+      cluster_version: '1.25.3'
+      local_kind_config_path: katalog/tests/kind-config.yml
+      pipeline_id: cluster-125
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+
+  - name: e2e
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.9.0_3.1.1_1.9.4_1.25.3_3.5.3_4.21.1
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [init]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-124
+      - bats -t katalog/tests/tests.sh
+      - bats -t katalog/tests/grafana-ldap.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
+    pull: always
+    depends_on: [e2e]
+    settings:
+      action: destroy
+      pipeline_id: cluster-125
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: shared
+    temp: {}
+---
 name: release
 kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.21
-  - e2e-kubernetes-1.22
   - e2e-kubernetes-1.23
   - e2e-kubernetes-1.24
+  - e2e-kubernetes-1.25
 
 platform:
   os: linux

--- a/katalog/node-exporter/MAINTENANCE.md
+++ b/katalog/node-exporter/MAINTENANCE.md
@@ -5,7 +5,7 @@ To prepare a new release of this package:
 1. Get the current upstream release
 
 ```bash
-export KUBE_PROMETHEUS_RELEASE=v0.11.0
+export KUBE_PROMETHEUS_RELEASE=v0.12.0
 ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} node-exporter
 ```
 

--- a/katalog/node-exporter/README.md
+++ b/katalog/node-exporter/README.md
@@ -8,15 +8,15 @@ enabled by default from the project's [repository][ne-gh]
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
+- Kubernetes >= `1.23.0`
 - Kustomize = `v3.5.3`
 - [prometheus-operator](../prometheus-operator)
 
 ## Image repository and tag
 
-* node-exporter image: `registry.sighup.io/fury/prometheus/node-exporter:v1.3.1`
+* node-exporter image: `registry.sighup.io/fury/prometheus/node-exporter:v1.5.0`
 * node-exporter repository: [Node-Exporter on Github][ne-gh]
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.12.0`
+- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.14.0`
 - kube-rbac-proxy repository: [kube-rbac-proxy on Github][krp-gh]
 
 ## Configuration

--- a/katalog/node-exporter/clusterRole.yaml
+++ b/katalog/node-exporter/clusterRole.yaml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.3.1
+    app.kubernetes.io/version: 1.5.0
   name: node-exporter
   namespace: monitoring
 rules:

--- a/katalog/node-exporter/clusterRoleBinding.yaml
+++ b/katalog/node-exporter/clusterRoleBinding.yaml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.3.1
+    app.kubernetes.io/version: 1.5.0
   name: node-exporter
   namespace: monitoring
 roleRef:

--- a/katalog/node-exporter/daemonset.yaml
+++ b/katalog/node-exporter/daemonset.yaml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.3.1
+    app.kubernetes.io/version: 1.5.0
   name: node-exporter
   namespace: monitoring
 spec:
@@ -26,7 +27,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: node-exporter
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 1.3.1
+        app.kubernetes.io/version: 1.5.0
     spec:
       automountServiceAccountToken: true
       containers:
@@ -34,12 +35,13 @@ spec:
         - --web.listen-address=127.0.0.1:9100
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
+        - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --no-collector.hwmon
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
-        image: quay.io/prometheus/node-exporter:v1.3.1
+        image: quay.io/prometheus/node-exporter:v1.5.0
         name: node-exporter
         resources:
           limits:
@@ -75,7 +77,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100

--- a/katalog/node-exporter/kustomization.yaml
+++ b/katalog/node-exporter/kustomization.yaml
@@ -14,10 +14,10 @@ images:
     newTag: "3"
   - name: quay.io/prometheus/node-exporter
     newName: registry.sighup.io/fury/prometheus/node-exporter
-    newTag: v1.3.1
+    newTag: v1.5.0
   - name: quay.io/coreos/kube-rbac-proxy
     newName: registry.sighup.io/fury/brancz/kube-rbac-proxy
-    newTag: v0.12.0
+    newTag: v0.14.0
 
 patchesStrategicMerge:
   - |-

--- a/katalog/node-exporter/prometheusRule.yaml
+++ b/katalog/node-exporter/prometheusRule.yaml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.3.1
+    app.kubernetes.io/version: 1.5.0
     prometheus: k8s
     role: alert-rules
   name: node-exporter-rules
@@ -198,15 +199,15 @@ spec:
         summary: Clock skew detected.
       expr: |
         (
-          node_timex_offset_seconds > 0.05
+          node_timex_offset_seconds{job="node-exporter"} > 0.05
         and
-          deriv(node_timex_offset_seconds[5m]) >= 0
+          deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) >= 0
         )
         or
         (
-          node_timex_offset_seconds < -0.05
+          node_timex_offset_seconds{job="node-exporter"} < -0.05
         and
-          deriv(node_timex_offset_seconds[5m]) <= 0
+          deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) <= 0
         )
       for: 10m
       labels:
@@ -218,9 +219,9 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodeclocknotsynchronising
         summary: Clock not synchronising.
       expr: |
-        min_over_time(node_timex_sync_status[5m]) == 0
+        min_over_time(node_timex_sync_status{job="node-exporter"}[5m]) == 0
         and
-        node_timex_maxerror_seconds >= 16
+        node_timex_maxerror_seconds{job="node-exporter"} >= 16
       for: 10m
       labels:
         severity: warning
@@ -232,7 +233,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/noderaiddegraded
         summary: RAID Array is degraded
       expr: |
-        node_md_disks_required - ignoring (state) (node_md_disks{state="active"}) > 0
+        node_md_disks_required{job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} - ignoring (state) (node_md_disks{state="active",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}) > 0
       for: 15m
       labels:
         severity: critical
@@ -243,7 +244,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/noderaiddiskfailure
         summary: Failed device in RAID array
       expr: |
-        node_md_disks{state="failed"} > 0
+        node_md_disks{state="failed",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
       labels:
         severity: warning
     - alert: NodeFileDescriptorLimit
@@ -314,10 +315,10 @@ spec:
         rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
       record: instance:node_vmstat_pgmajfault:rate5m
     - expr: |
-        rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[5m])
+        rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_seconds:rate5m
     - expr: |
-        rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[5m])
+        rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_weighted_seconds:rate5m
     - expr: |
         sum without (device) (

--- a/katalog/node-exporter/service.yaml
+++ b/katalog/node-exporter/service.yaml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.3.1
+    app.kubernetes.io/version: 1.5.0
   name: node-exporter
   namespace: monitoring
 spec:

--- a/katalog/node-exporter/serviceAccount.yaml
+++ b/katalog/node-exporter/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+---
 apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
@@ -10,6 +11,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.3.1
+    app.kubernetes.io/version: 1.5.0
   name: node-exporter
   namespace: monitoring

--- a/katalog/node-exporter/serviceMonitor.yaml
+++ b/katalog/node-exporter/serviceMonitor.yaml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.3.1
+    app.kubernetes.io/version: 1.5.0
   name: node-exporter
   namespace: monitoring
 spec:


### PR DESCRIPTION
e2e tests are failing, this PR only addresses node-exporter and adds 1.25 to the CI