### PR TITLE
[Alertmanager] Improve DeadMansSwitch intervals

### DIFF
--- a/katalog/alertmanager-operated/MAINTENANCE.md
+++ b/katalog/alertmanager-operated/MAINTENANCE.md
@@ -16,3 +16,11 @@ export KUBE_PROMETHEUS_RELEASE=v0.11.0
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
+
+5. Check that the `DeadMansSwitch` alerts in the current configuration have the following parameters and not the default ones:
+
+```yaml
+repeatInterval: 30s
+groupWait: 1m
+groupInterval: 1m
+```

--- a/katalog/alertmanager-operated/alertmanagerconfig.yml
+++ b/katalog/alertmanager-operated/alertmanagerconfig.yml
@@ -15,6 +15,9 @@ spec:
         matchType: "="
         value: DeadMansSwitch
     receiver: healthchecks
+    repeatInterval: 50s
+    groupWait: 0s
+    groupInterval: 1m
   receivers:
     - name: healthchecks
       webhookConfigs:

--- a/katalog/alertmanager-operated/alertmanagerconfig.yml
+++ b/katalog/alertmanager-operated/alertmanagerconfig.yml
@@ -15,8 +15,8 @@ spec:
         matchType: "="
         value: DeadMansSwitch
     receiver: healthchecks
-    repeatInterval: 50s
-    groupWait: 0s
+    repeatInterval: 30s
+    groupWait: 1m
     groupInterval: 1m
   receivers:
     - name: healthchecks


### PR DESCRIPTION
Hello! 
I propose changing the frequency of DeadMansSwitch alerts.
I suggest for group_wait, group_interval, and repeat_interval not use default values here because this alert is serving a different purpose than the others.
We totally don’t want to wait for it to be fired or hold back on repeats because we want it to go off at a more consistent rate.