### PR TITLE
FEAT: update blackbox exporter to the latest stable version

### DIFF
--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -9,7 +9,7 @@ TBD
 | Component             | Supported Version                                                                            | Previous Version |
 | --------------------- | -------------------------------------------------------------------------------------------- | ---------------- |
 | `alertmanager`        | [`v0.24.0`](https://github.com/prometheus/alertmanager/releases/tag/v0.24.0)                 | `No Update`      |
-| `blackbox-exporter`   | [`v0.23.0`](https://github.com/prometheus/blackbox_exporter/releases/tag/v0.23.0)            | `v.0.21.0`       |
+| `blackbox-exporter`   | [`v0.23.0`](https://github.com/prometheus/blackbox_exporter/releases/tag/v0.23.0)            | `v0.21.0`        |
 | `grafana`             | [`v8.5.5`](https://github.com/grafana/grafana/releases/tag/v8.5.5)                           | `No Update`      |
 | `kube-rbac-proxy`     | [`v0.12.0`](https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.12.0)                  | `No Update`      |
 | `kube-state-metrics`  | [`v2.5.0`](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.5.0)             | `No Update`      |

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -9,14 +9,14 @@ TBD
 | Component             | Supported Version                                                                            | Previous Version |
 | --------------------- | -------------------------------------------------------------------------------------------- | ---------------- |
 | `alertmanager`        | [`v0.24.0`](https://github.com/prometheus/alertmanager/releases/tag/v0.24.0)                 | `No Update`      |
-| `blackbox-exporter`   | [`v0.21.0`](https://github.com/prometheus/blackbox_exporter/releases/tag/v0.21.0)            | `No Update`      |
+| `blackbox-exporter`   | [`v0.23.0`](https://github.com/prometheus/blackbox_exporter/releases/tag/v0.23.0)            | `v.0.21.0`       |
 | `grafana`             | [`v8.5.5`](https://github.com/grafana/grafana/releases/tag/v8.5.5)                           | `No Update`      |
 | `kube-rbac-proxy`     | [`v0.12.0`](https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.12.0)                  | `No Update`      |
 | `kube-state-metrics`  | [`v2.5.0`](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.5.0)             | `No Update`      |
 | `node-exporter`       | [`v1.3.1`](https://github.com/prometheus/node_exporter/releases/tag/v1.3.1)                  | `No Update`      |
 | `prometheus-adapter`  | [`v0.9.1`](https://github.com/kubernetes-sigs/prometheus-adapter/releases/tag/v0.9.1)        | `No Update`      |
-| `prometheus-operator` | [`v0.62.0`](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.62.0) |  `v0.57.0`       |
-| `prometheus`          | [`v2.41.0`](https://github.com/prometheus/prometheus/releases/tag/v2.41.0)                   |  `v2.36.1`       |
+| `prometheus-operator` | [`v0.62.0`](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.62.0) | `v0.57.0`        |
+| `prometheus`          | [`v2.41.0`](https://github.com/prometheus/prometheus/releases/tag/v2.41.0)                   | `v2.36.1`        |
 | `thanos`              | [`v0.24.0`](https://github.com/thanos-io/thanos/releases/tag/v0.24.0)                        | `No Update`      |
 | `x509-exporter`       | [`v3.2.0`](https://github.com/enix/x509-certificate-exporter/releases/tag/v3.2.0)            | `No Update`      |
 

--- a/katalog/blackbox-exporter/MAINTENANCE.md
+++ b/katalog/blackbox-exporter/MAINTENANCE.md
@@ -5,7 +5,7 @@ To prepare a new release of this package:
 1. Get the current upstream release
 
 ```bash
-export KUBE_PROMETHEUS_RELEASE=v0.11.0
+export KUBE_PROMETHEUS_RELEASE=v0.12.0
 ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} blackbox-exporter
 ```
 

--- a/katalog/blackbox-exporter/README.md
+++ b/katalog/blackbox-exporter/README.md
@@ -8,17 +8,17 @@ The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
+- Kubernetes >= `1.24.0`
 - Kustomize = `v3.5.3`
 - [prometheus-operator](../prometheus-operator)
 
 ## Image repository and tag
 
-- Blackbox exporter image: `registry.sighup.io/fury/prometheus/blackbox-exporter:v0.21.0`
+- Blackbox exporter image: `registry.sighup.io/fury/prometheus/blackbox-exporter:v0.24.0`
 - Blackbox exporter repository: [Blackbox exporter on GitHub][blackbox-exporter-gh]
 - Kubernetes ConfigMap Reload image: `registry.sighup.io/fury/jimmidyson/configmap-reload:v0.5.0`
 - Kubernetes ConfigMap Reload repository: [Kubernetes ConfigMap Reload on GitHub][configmap-reload-gh]
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.12.0`
+- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.14.0`
 - kube-rbac-proxy repository: [kube-rbac-proxy on Github][krp-gh]
 
 ## Configuration

--- a/katalog/blackbox-exporter/clusterRoleBinding.yaml
+++ b/katalog/blackbox-exporter/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.21.0
+    app.kubernetes.io/version: 0.23.0
   name: blackbox-exporter
   namespace: monitoring
 roleRef:

--- a/katalog/blackbox-exporter/configuration.yaml
+++ b/katalog/blackbox-exporter/configuration.yaml
@@ -50,6 +50,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.21.0
+    app.kubernetes.io/version: 0.23.0
   name: blackbox-exporter-configuration
   namespace: monitoring

--- a/katalog/blackbox-exporter/deployment.yaml
+++ b/katalog/blackbox-exporter/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.21.0
+    app.kubernetes.io/version: 0.23.0
   name: blackbox-exporter
   namespace: monitoring
 spec:
@@ -27,14 +27,14 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: blackbox-exporter
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 0.21.0
+        app.kubernetes.io/version: 0.23.0
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
         - --config.file=/etc/blackbox_exporter/config.yml
         - --web.listen-address=:19115
-        image: quay.io/prometheus/blackbox-exporter:v0.21.0
+        image: quay.io/prometheus/blackbox-exporter:v0.23.0
         name: blackbox-exporter
         ports:
         - containerPort: 19115
@@ -89,7 +89,7 @@ spec:
         - --secure-listen-address=:9115
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:19115/
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.14.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9115

--- a/katalog/blackbox-exporter/kustomization.yaml
+++ b/katalog/blackbox-exporter/kustomization.yaml
@@ -11,13 +11,13 @@ namespace: monitoring
 images:
   - name: quay.io/prometheus/blackbox-exporter
     newName: registry.sighup.io/fury/prometheus/blackbox-exporter
-    newTag: v0.21.0
+    newTag: v0.23.0
   - name: jimmidyson/configmap-reload
     newName: registry.sighup.io/fury/jimmidyson/configmap-reload
     newTag: v0.5.0
   - name: quay.io/brancz/kube-rbac-proxy
     newName: registry.sighup.io/fury/brancz/kube-rbac-proxy
-    newTag: v0.12.0
+    newTag: v0.14.0
 
 resources:
   - clusterRole.yaml

--- a/katalog/blackbox-exporter/service.yaml
+++ b/katalog/blackbox-exporter/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.21.0
+    app.kubernetes.io/version: 0.23.0
   name: blackbox-exporter
   namespace: monitoring
 spec:

--- a/katalog/blackbox-exporter/serviceAccount.yaml
+++ b/katalog/blackbox-exporter/serviceAccount.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.21.0
+    app.kubernetes.io/version: 0.23.0
   name: blackbox-exporter
   namespace: monitoring

--- a/katalog/blackbox-exporter/serviceMonitor.yaml
+++ b/katalog/blackbox-exporter/serviceMonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.21.0
+    app.kubernetes.io/version: 0.23.0
   name: blackbox-exporter
   namespace: monitoring
 spec:


### PR DESCRIPTION
As per title, updated blackbox-exporter package and tested with 1.25