### PR TITLE
fix(AlertManager): set Config Matcher Strategy to None

### DIFF
--- a/katalog/alertmanager-operated/alertmanager.yaml
+++ b/katalog/alertmanager-operated/alertmanager.yaml
@@ -15,6 +15,11 @@ metadata:
   namespace: monitoring
 spec:
   image: quay.io/prometheus/alertmanager:v0.25.0
+  # We set the matcher strategy to None, because otherwise the Prometheus
+  # Operator will add a matcher to all routes checking for a namespace label
+  # with the namespace where alertmanager is running.
+  alertmanagerConfigMatcherStrategy:
+    type: None
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:


### PR DESCRIPTION
This PR sets config matcher strategy to None for Alertmanager's definition, otherwise the Prometheus Operator will add to all the routes a matcher for a label `namespace=<namespace where alertmanager is running>`, breaking our routes.

Fixes #132

As you can see, now the routes don't have the namespace matcher added automatically anymore:

```console
$ zcat /etc/alertmanager/config/alertmanager.yaml.gz
global:
  resolve_timeout: 5m
route:
  receiver: noreceiver
  group_by:
  - alertname
  routes:
  - receiver: monitoring/deadmanswitch/healthchecks
    matchers:
    - alertname="DeadMansSwitch"
    continue: true
    group_wait: 1m
    group_interval: 1m
    repeat_interval: 30s
  - receiver: monitoring/infra/infra
    group_by:
    - alertname
    matchers:
    - namespace=~"calico-api|calico-system|cert-manager|gatekeeper-system|ingress-nginx|kube-system|logging|monitoring|pomerium|tigera-operator|vmware-system-csi"
    - alertname=~"TargetDown|KubePersistentVolumeFillingUp|NginxIngressCertificateExpiration|NginxIngressLatencyTooHigh|NginxIngressFailedReload|NginxIngressFailureRate|NginxIngressDown"
    continue: true
  - receiver: monitoring/k8s/k8s
    group_by:
    - alertname
    matchers:
    - alertname=~"NodeNetworkInterfaceFlapping|NodeClockSkewDetected|KubeAPIDown|KubeletDown|KubeletTooManyPods|KubeNodeNotReady|KubeClientCertificateExpiration|NodeFileDescriptorLimit|NodeFilesystemAlmostOutOfFiles|NodeFilesystemAlmostOutOfSpace|NodeFilesystemFilesFillingUp|NodeFilesystemSpaceFillingUp|NodeRAIDDegraded|NodeRAIDDiskFailure|etcdInsufficientMembers|etcdMembersDown|etcdNoLeader|CoreDNSPanic|CoreDNSHealthRequestsLatency|KubeControllerManagerDown|KubeSchedulerDown|PrometheusRuleFailures|AlertmanagerClusterDown|AlertmanagerConfigInconsistent|AlertmanagerFailedReload|X509CertificateExpiration|X509CertificateRenewal"
    continue: true
  group_wait: 30s
  group_interval: 1s
  repeat_interval: 1h
receivers:
- name: noreceiver
- name: monitoring/deadmanswitch/healthchecks
  webhook_configs:
  - url: https://algozino.com.ar/healthchecks
- name: monitoring/infra/infra
  slack_configs:
  - send_resolved: true
    api_url: https://algozino.com.ar/infra-slack
- name: monitoring/k8s/k8s
  slack_configs:
  - send_resolved: true
    api_url: https://algozino.com.ar/k8s-slack
templates:
- /etc/alertmanager/config/*.tmpl
```