### PR TITLE
feat(thanos/minio): add alerts for minio-monitoring

### DIFF
--- a/katalog/thanos/thanos-minio/base/minio-ha/MAINTENANCE.md
+++ b/katalog/thanos/thanos-minio/base/minio-ha/MAINTENANCE.md
@@ -18,3 +18,12 @@ What was customized (what differs from the helm template command):
 - Add `preferredDuringSchedulingIgnoredDuringExecution` on minio pods
 
 [github-releases]: https://github.com/minio/minio/releases
+
+## Prometheus Alerts
+
+The included prometheus alerts for MinIO are taken from here: <https://awesome-prometheus-alerts.grep.to/rules.html#minio-1>
+
+References:
+
+- <https://min.io/docs/minio/kubernetes/upstream/operations/monitoring/metrics-and-alerts.html>
+- <https://min.io/docs/minio/linux/operations/monitoring/collect-minio-metrics-using-prometheus.html#configure-an-alert-rule-using-minio-metrics>

--- a/katalog/thanos/thanos-minio/base/minio-ha/kustomization.yaml
+++ b/katalog/thanos/thanos-minio/base/minio-ha/kustomization.yaml
@@ -11,6 +11,7 @@ namespace: monitoring
 resources:
   - deploy.yaml
   - initialize-minio-buckets.yaml
+  - prometheusrules.yaml
 
 images:
   - name: registry.sighup.io/fury/groundnuty/k8s-wait-for

--- a/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
+++ b/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
@@ -16,7 +16,7 @@ spec:
     - name: minio.rules
       rules:
         - alert: MinioClusterDiskOffline
-          expr: minio_cluster_disk_offline_total > 0
+          expr: minio_cluster_disk_offline_total{job="minio-monitoring"} > 0
           for: 5m
           labels:
             severity: critical
@@ -24,7 +24,7 @@ spec:
             summary: Minio cluster disk offline (instance {{ $labels.instance }})
             description: "Minio cluster disk is offline\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
         - alert: MinioNodeDiskOffline
-          expr: minio_cluster_nodes_offline_total > 0
+          expr: minio_cluster_nodes_offline_total{job="minio-monitoring"} > 0
           for: 5m
           labels:
             severity: critical
@@ -32,7 +32,7 @@ spec:
             summary: Minio node disk offline (instance {{ $labels.instance }})
             description: "Minio cluster node disk is offline\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
         - alert: MinioDiskSpaceUsage
-          expr: disk_storage_available / disk_storage_total * 100 < 10
+          expr: disk_storage_available{job="minio-monitoring"} / disk_storage_total{job="minio-monitoring"} * 100 < 10
           for: 5m
           labels:
             severity: warning

--- a/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
+++ b/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
             summary: Minio node disk offline (instance {{ $labels.instance }})
             description: "Minio cluster node disk is offline\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
         - alert: MinioDiskSpaceUsage
-          expr: disk_storage_available{job="minio-monitoring"} / disk_storage_total{job="minio-monitoring"} * 100 < 10
+          expr: minio_cluster_capacity_usable_free_bytes{job="minio-monitoring"} / minio_cluster_capacity_usable_total_bytes{job="minio-monitoring"} * 100 < 10
           for: 5m
           labels:
             severity: warning

--- a/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
+++ b/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
@@ -15,7 +15,7 @@ spec:
   groups:
     - name: minio.rules
       rules:
-        - alert: MinioClusterDiskOffline
+        - alert: MinioMonitoringClusterDiskOffline
           expr: minio_cluster_disk_offline_total{job="minio-monitoring"} > 0
           for: 5m
           labels:
@@ -23,7 +23,7 @@ spec:
           annotations:
             summary: Minio cluster disk offline (instance {{ $labels.instance }})
             description: "Minio cluster disk is offline\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-        - alert: MinioNodeDiskOffline
+        - alert: MinioMonitoringNodeDiskOffline
           expr: minio_cluster_nodes_offline_total{job="minio-monitoring"} > 0
           for: 5m
           labels:
@@ -31,7 +31,7 @@ spec:
           annotations:
             summary: Minio node disk offline (instance {{ $labels.instance }})
             description: "Minio cluster node disk is offline\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-        - alert: MinioDiskSpaceUsage
+        - alert: MinioMonitoringDiskSpaceUsage
           expr: minio_cluster_capacity_usable_free_bytes{job="minio-monitoring"} / minio_cluster_capacity_usable_total_bytes{job="minio-monitoring"} * 100 < 10
           for: 5m
           labels:

--- a/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
+++ b/katalog/thanos/thanos-minio/base/minio-ha/prometheusrules.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: minio-monitoring-rules
+  namespace: monitoring
+spec:
+  groups:
+    - name: minio.rules
+      rules:
+        - alert: MinioClusterDiskOffline
+          expr: minio_cluster_disk_offline_total > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Minio cluster disk offline (instance {{ $labels.instance }})
+            description: "Minio cluster disk is offline\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        - alert: MinioNodeDiskOffline
+          expr: minio_cluster_nodes_offline_total > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Minio node disk offline (instance {{ $labels.instance }})
+            description: "Minio cluster node disk is offline\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        - alert: MinioDiskSpaceUsage
+          expr: disk_storage_available / disk_storage_total * 100 < 10
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Minio disk space usage (instance {{ $labels.instance }})
+            description: "Minio available free space is low (< 10%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
Add 3 alerts for the included minio deployment: when disks are offline, when minio nodes are offline and when the available capacity is less than 10 percent.