### PR TITLE
feat(grafana): add folder generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 | [furyctl][furyctl-repo]     | `>=0.6.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
 | [kustomize][kustomize-repo] | `>=3.5.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 
-## Deployment
+### Deployment
 
 1. List the packages you want to deploy and their version in a `Furyfile.yml`
 
@@ -210,7 +210,7 @@ service provider as follows:
 kustomize build . | kubectl apply -f - --server-side
 ```
 
-## Examples
+### Examples
 
 To see examples of how to customize Fury Kubernetes Monitoring packages, please
 go to the [examples](examples) directory.

--- a/katalog/alertmanager-operated/dashboards/kustomization.yaml
+++ b/katalog/alertmanager-operated/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: monitoring
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Monitoring"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/configs/bases/coredns/kustomization.yaml
+++ b/katalog/configs/bases/coredns/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: kube-system
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Kubernetes Components"
   disableNameSuffixHash: true
 
 resources:

--- a/katalog/configs/bases/default/kustomization.yaml
+++ b/katalog/configs/bases/default/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: kube-system
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Workloads"
   disableNameSuffixHash: true
 
 resources:

--- a/katalog/configs/kubeadm/kustomization.yaml
+++ b/katalog/configs/kubeadm/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: kube-system
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Kubernetes Components"
   disableNameSuffixHash: true
 
 resources:

--- a/katalog/grafana/MAINTENANCE.md
+++ b/katalog/grafana/MAINTENANCE.md
@@ -16,3 +16,8 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
+
+## Customizations
+
+- We've changed the json file inside grafana-dashboardSources, dropping the folder name and enbling the option to use subfolders.
+- Added `FOLDER_ANNOTATION` environment variable to the dashboards sidecar.

--- a/katalog/grafana/README.md
+++ b/katalog/grafana/README.md
@@ -7,7 +7,7 @@ numeric time-series data with Prometheus integration.
 
 ## Image repository and tag
 
-- Grafana image: `grafana/grafana:8.5.5`
+- Grafana image: `grafana/grafana:9.3.2`
 - Grafana repository: [https://github.com/grafana/grafana](https://github.com/grafana/grafana)
 - Grafana documentation: [https://docs.grafana.org](https://docs.grafana.org)
 - k8s-sidecar image: `kiwigrid/k8s-sidecar`
@@ -32,17 +32,22 @@ Fury distribution Grafana is deployed with the following configuration:
 
 ## Add new dashboards
 
-You can create a ConfigMap/Secret in your namespace with a JSON of a grafana dashboard
-and then labeling it with the label key `grafana-sighup-dashboard`, the value
-of the label is up to you. Labeling it, the sidecar k8s-sidecar will take care of it and inject
-it into a shared volume where grafana does a lookup and discover it.
-Look at the [dashboards](dashboards) folder `kustomization.yaml` for an example.
+Grafana will try to load automatically all the files inside configMaps that have the `grafana-sighup-dashboard` label from **all** namespaces.
+
+To add a custom dashboard to Grafana, follow the next steps:
+
+1. Create a configMap that includes the dashboard definition `json` file (you can include more than one json per configMap)
+2. Add the `grafana-sighup-dashboard` **label** to the configMap, the value is not important.
+3. If you want to put the dashboard(s) in a specific Grafana folder, for example `myfolder`, add the following **annotation** to the configMap: `grafana-folder: myfolder`.
+
+Look at the [dashboards](dashboards) folder `kustomization.yaml` for some examples.
 
 ## Add new datasource
 
 Additionally, you can create a ConfigMap/Secret in your namespace with a datasource definition then labeling it
 with the label key `grafana-sighup-datasource`, the value of the label is up to you. Labeling it, the sidecar k8s-sidecar
 will take care of it and inject it into a shared volume and send an API reload signal to grafana itself.
+
 Look at the [datasources](datasources) folder `kustomization.yaml` for an example.
 
 ## Deployment

--- a/katalog/grafana/dashboardSources.yaml
+++ b/katalog/grafana/dashboardSources.yaml
@@ -4,16 +4,17 @@
 
 apiVersion: v1
 data:
-  dashboards.yaml: |-
+  general.yaml: |-
     {
         "apiVersion": 1,
         "providers": [
             {
-                "folder": "Default",
+                "folder": "",
                 "folderUid": "",
                 "name": "0",
                 "options": {
-                    "path": "/grafana-dashboard-definitions/0"
+                    "path": "/grafana-dashboard-definitions/",
+                    "foldersFromFilesStructure": true
                 },
                 "orgId": 1,
                 "type": "file"

--- a/katalog/grafana/dashboards/kustomization.yaml
+++ b/katalog/grafana/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: monitoring
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Monitoring"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/grafana/patches/grafana-dashboard-sidecar.yml
+++ b/katalog/grafana/patches/grafana-dashboard-sidecar.yml
@@ -19,6 +19,8 @@ spec:
               value: "grafana-sighup-dashboard"
             - name: FOLDER
               value: /tmp/dashboards
+            - name: FOLDER_ANNOTATION
+              value: "grafana-folder"
             - name: RESOURCE
               # configmap and secret
               value: both
@@ -38,5 +40,5 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
           volumeMounts:
-              - name: grafana-dashboards
-                mountPath: /tmp/dashboards
+            - name: grafana-dashboards
+              mountPath: /tmp/dashboards

--- a/katalog/grafana/patches/grafana-volumes.yaml
+++ b/katalog/grafana/patches/grafana-volumes.yaml
@@ -16,7 +16,7 @@ spec:
             - mountPath: /etc/grafana
               name: grafana-config
               readOnly: false
-            - mountPath: /grafana-dashboard-definitions/0
+            - mountPath: /grafana-dashboard-definitions/
               name: grafana-dashboards
             - mountPath: /etc/grafana/provisioning/dashboards
               name: grafana-dashboards-provisioning

--- a/katalog/kube-proxy-metrics/dashboards/kustomization.yaml
+++ b/katalog/kube-proxy-metrics/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: kube-system
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Kubernetes Components"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/kube-state-metrics/dashboards/kustomization.yaml
+++ b/katalog/kube-state-metrics/dashboards/kustomization.yaml
@@ -9,6 +9,8 @@ kind: Kustomization
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Workloads"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/node-exporter/dashboards/kustomization.yaml
+++ b/katalog/node-exporter/dashboards/kustomization.yaml
@@ -9,6 +9,8 @@ kind: Kustomization
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Kubernetes Components"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/prometheus-operated/README.md
+++ b/katalog/prometheus-operated/README.md
@@ -5,7 +5,7 @@
 Prometheus Operated deploys Prometheus instances via Prometheus CRD as defined
 by [Prometheus Operator](../prometheus-operator).
 
-Prometheus is a monitoring tool to collect metric based time series data and
+Prometheus is a monitoring tool to collect metrics-based time series data and
 provides a functional expression language that lets the user select and
 aggregate time-series data in real-time. Prometheus's expression browser makes it
 possible to analyze queried data as a graph or view it as tabular data, but it's
@@ -21,9 +21,9 @@ Grafana. Grafana integration is provided in Fury monitoring katalog, please see
 
 ## Image repository and tag
 
-* Prometheus image: `registry.sighup.io/prometheus/prometheus:v2.41.1`
-* Prometheus repository: [Prometheus on Github][prom-gh]
-* Prometheus documentation: [Prometheus documentation site][prom-doc]
+- Prometheus image: `registry.sighup.io/prometheus/prometheus:v2.41.1`
+- Prometheus repository: [Prometheus on Github][prom-gh]
+- Prometheus documentation: [Prometheus documentation site][prom-doc]
 
 ## Configuration
 
@@ -64,8 +64,7 @@ Target discovery is achieved via ServiceMonitor CRD, to learn more about
 ServiceMonitor please follow Prometheus Operator's
 [documentation](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/running-exporters.md).
 
-To learn how to create ServiceMonitor resources for your services please see the
-[example][example].
+To learn how to create ServiceMonitor resources for your services please see the [example][example].
 
 ### Prometheus Rules and Alerts
 
@@ -80,106 +79,115 @@ To learn how to define alert rules for your services please see the
 
 ## Alerts
 
-The followings alerts are already defined for this package.
+The following alerts are already defined for this package.
 
 ### kubernetes-apps
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| KubePodCrashLooping | This alert fires if the per-second rate of the total number of restart of a given pod in a 15 minutes time window was above 0 in the last hour, i.e. the pod is stuck in a crash loop. | warning | 1h |
-| KubePodNotReady | This alert fires if at least one pod was stuck in the Pending or Unknown phase in the last hour. | warning | 1h |
-| KubeDeploymentGenerationMismatch | This alert fires if in the last hour a deployment's observed generation (the revision number recorded in the object status) was different from the metadata generation (the revision number in the deployment metadata). | warning | 15m |
-| KubeDeploymentReplicasMismatch | This alert fires if a deployment's replicas number specification was different from the available replicas in the last hour. | warning | 1h |
-| KubeStatefulSetReplicasMismatch | This alert fires if a deployment's replicas number specification was different from the available replicas in the last hour. | warning | 15m |
-| KubeStatefulSetGenerationMismatch | This alert fires if a StatefulSet's replicas number specification was different from the available replicas in the 15 minutes. | warning | 15m |
-| KubeDaemonSetRolloutStuck | This alert fires if the percentage of DaemonSet in the ready phase was less than 100% in the last 15 minutes. | warning | 15m |
-| KubeDaemonSetNotScheduled | This alert fires if the desired number of scheduled DaemonSet was higher than the number of currently scheduled DaemonSet in the last 10 minutes. | warning | 10m |
-| KubeDaemonSetMisScheduled | This alert fires if at least one DaemonSet was running where it was not supposed to run in the last 10 minutes. | warning | 10m |
-| KubeCronJobRunning |  This alert fires if at least one CronJob took more than one hour to complete. | warning | 1h |
-| KubeJobCompletion | This alert fires if at least on Job took more than one hour to complete. | warning | 1h |
-| KubeJobFailed | This alert fires if at least one Job failed in the last hour. | warning | 1h |
-| KubeLatestImageTag | This alert fires if there are images deployed in the cluster tagged with `:latest` and this is really dangerous | warning | 1h |
+
+| Parameter                         | Description                                                                                                                                                                                                              | Severity | Interval |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | :------: |
+| KubePodCrashLooping               | This alert fires if the per-second rate of the total number of restart of a given pod in a 15 minutes time window was above 0 in the last hour, i.e. the pod is stuck in a crash loop.                                   | warning  |    1h    |
+| KubePodNotReady                   | This alert fires if at least one pod was stuck in the Pending or Unknown phase in the last hour.                                                                                                                         | warning  |    1h    |
+| KubeDeploymentGenerationMismatch  | This alert fires if in the last hour a deployment's observed generation (the revision number recorded in the object status) was different from the metadata generation (the revision number in the deployment metadata). | warning  |   15m    |
+| KubeDeploymentReplicasMismatch    | This alert fires if a deployment's replicas number specification was different from the available replicas in the last hour.                                                                                             | warning  |    1h    |
+| KubeStatefulSetReplicasMismatch   | This alert fires if a deployment's replicas number specification was different from the available replicas in the last hour.                                                                                             | warning  |   15m    |
+| KubeStatefulSetGenerationMismatch | This alert fires if a StatefulSet's replicas number specification was different from the available replicas in the 15 minutes.                                                                                           | warning  |   15m    |
+| KubeDaemonSetRolloutStuck         | This alert fires if the percentage of DaemonSet in the ready phase was less than 100% in the last 15 minutes.                                                                                                            | warning  |   15m    |
+| KubeDaemonSetNotScheduled         | This alert fires if the desired number of scheduled DaemonSet was higher than the number of currently scheduled DaemonSet in the last 10 minutes.                                                                        | warning  |   10m    |
+| KubeDaemonSetMisScheduled         | This alert fires if at least one DaemonSet was running where it was not supposed to run in the last 10 minutes.                                                                                                          | warning  |   10m    |
+| KubeCronJobRunning                | This alert fires if at least one CronJob took more than one hour to complete.                                                                                                                                            | warning  |    1h    |
+| KubeJobCompletion                 | This alert fires if at least on Job took more than one hour to complete.                                                                                                                                                 | warning  |    1h    |
+| KubeJobFailed                     | This alert fires if at least one Job failed in the last hour.                                                                                                                                                            | warning  |    1h    |
+| KubeLatestImageTag                | This alert fires if there are images deployed in the cluster tagged with `:latest` and this is really dangerous                                                                                                          | warning  |    1h    |
 
 ### kube-prometheus-node-alerting.rules
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| NodeCPUSaturating | This alert fires if, for a given instance, CPU utilisation and saturation were higher than 90% in the last 30 minutes. | warning | 30m |
-| NodeCPUStuckInIOWait | This alert fires if CPU time in IOWait mode calculated on a 5 minutes window for a given instance was more than 50% in the last 15 minutes. | warning | 15m |
-| NodeMemoryRunningFull | This alert fires if memory utilisation on a given node was higher than 85% in the last 30 minutes. | warning | 30m |
-| NodeFilesystemUsageCritical | This alert fires if in the last minute the filesystem usage was more than 90%. | critical | 1m |
-| NodeFilesystemFullInFourDays | This alert fires if in the last 5 minutes the filesystem usage was more than 85% and, based on a linear prediction on the volume usage in the last 6 hours, the volume will be full in four days. | warning | 5m |
-| NodeFilesystemInodeUsageCritical | This alert fires if the available inodes in a given filesystem were less than 10% in the last minute. | critical | 1m |
-| NodeFilesystemInodeFullInFourDays | This alert fires if, based on a linear prediction on the inodes usage in the last 6 hours, the filesystem will exhaust its inodes in four days. | warning | 5m |
-| NodeNetworkDroppingPackets | This alerts fires if a given physical network interface was dropping more than 10 pkt/s in the last 30 minutes. | warning | 30m |
+
+| Parameter                         | Description                                                                                                                                                                                       | Severity | Interval |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| NodeCPUSaturating                 | This alert fires if, for a given instance, CPU utilisation and saturation were higher than 90% in the last 30 minutes.                                                                            | warning  |   30m    |
+| NodeCPUStuckInIOWait              | This alert fires if CPU time in IOWait mode calculated on a 5 minutes window for a given instance was more than 50% in the last 15 minutes.                                                       | warning  |   15m    |
+| NodeMemoryRunningFull             | This alert fires if memory utilisation on a given node was higher than 85% in the last 30 minutes.                                                                                                | warning  |   30m    |
+| NodeFilesystemUsageCritical       | This alert fires if in the last minute the filesystem usage was more than 90%.                                                                                                                    | critical |    1m    |
+| NodeFilesystemFullInFourDays      | This alert fires if in the last 5 minutes the filesystem usage was more than 85% and, based on a linear prediction on the volume usage in the last 6 hours, the volume will be full in four days. | warning  |    5m    |
+| NodeFilesystemInodeUsageCritical  | This alert fires if the available inodes in a given filesystem were less than 10% in the last minute.                                                                                             | critical |    1m    |
+| NodeFilesystemInodeFullInFourDays | This alert fires if, based on a linear prediction on the inodes usage in the last 6 hours, the filesystem will exhaust its inodes in four days.                                                   | warning  |    5m    |
+| NodeNetworkDroppingPackets        | This alerts fires if a given physical network interface was dropping more than 10 pkt/s in the last 30 minutes.                                                                                   | warning  |   30m    |
 
 ### prometheus
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| PrometheusConfigReloadFailed | This alert fires if Prometheus's configuration failed to reload in the last 10 minutes. | critical | 10m |
-| PrometheusNotificationQueueRunningFull | This alert fires if Prometheus's alert notification queue is running full in the next 30 minutes, based on a linear prediction on the usage in the last 5 minutes. | critical | 10m |
-| PrometheusErrorSendingAlerts | This alert fires if the error rate calculated in a 5 minutes time windows was more than 1% in the last 10 minutes. | critical | 10m |
-| PrometheusErrorSendingAlerts | This alert fires if the error rate calculated in a 5 minutes time windows was more than 3% in the last 10 minutes. | critical | 10m |
-| PrometheusNotConnectedToAlertmanagers | This alert fires if Prometheus was not connected to at least one Alertmanager in the last 10 minutes. | critical | 10m |
-| PrometheusTSDBReloadsFailing | This alert fires if Prometheus had any failure to reload data blocks from disk in the last 12 hours. | critical | 12h |
-| PrometheusTSDBCompactionsFailing | This alert fires if Prometheus had any failure to compact sample blocks in the last 12 hours. | critical | 12h |
-| PrometheusTSDBWALCorruptions | This alert fires if Prometheus had detected any corruption in the write-ahead log in the last 4 hours. | critical | 4h |
-| PrometheusNotIngestingSamples | This alert fires if Prometheus sample ingestion rate calculated on a 5 minutes time window was below or equal to 0 in the last 10 minutes, i.e. Prometheus is failing to ingest samples. | critical | 10m |
-| PrometheusTargetScrapesDuplicate | This alert fires if Prometheus was discarding many samples due to duplicated timestamps but different values in the last 10 minutes. | warning | 10m |
+
+| Parameter                              | Description                                                                                                                                                                              | Severity | Interval |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| PrometheusConfigReloadFailed           | This alert fires if Prometheus's configuration failed to reload in the last 10 minutes.                                                                                                  | critical |   10m    |
+| PrometheusNotificationQueueRunningFull | This alert fires if Prometheus's alert notification queue is running full in the next 30 minutes, based on a linear prediction on the usage in the last 5 minutes.                       | critical |   10m    |
+| PrometheusErrorSendingAlerts           | This alert fires if the error rate calculated in a 5 minutes time windows was more than 1% in the last 10 minutes.                                                                       | critical |   10m    |
+| PrometheusErrorSendingAlerts           | This alert fires if the error rate calculated in a 5 minutes time windows was more than 3% in the last 10 minutes.                                                                       | critical |   10m    |
+| PrometheusNotConnectedToAlertmanagers  | This alert fires if Prometheus was not connected to at least one Alertmanager in the last 10 minutes.                                                                                    | critical |   10m    |
+| PrometheusTSDBReloadsFailing           | This alert fires if Prometheus had any failure to reload data blocks from disk in the last 12 hours.                                                                                     | critical |   12h    |
+| PrometheusTSDBCompactionsFailing       | This alert fires if Prometheus had any failure to compact sample blocks in the last 12 hours.                                                                                            | critical |   12h    |
+| PrometheusTSDBWALCorruptions           | This alert fires if Prometheus had detected any corruption in the write-ahead log in the last 4 hours.                                                                                   | critical |    4h    |
+| PrometheusNotIngestingSamples          | This alert fires if Prometheus sample ingestion rate calculated on a 5 minutes time window was below or equal to 0 in the last 10 minutes, i.e. Prometheus is failing to ingest samples. | critical |   10m    |
+| PrometheusTargetScrapesDuplicate       | This alert fires if Prometheus was discarding many samples due to duplicated timestamps but different values in the last 10 minutes.                                                     | warning  |   10m    |
 
 ### general
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| TargetDown | This alert fires if more than 10% of the targets were down in the last 10 minutes. | critical | 10m |
-| FdExhaustion | This alert fires if, based on a linear prediction on file descriptors usage in the last hour minutes, the instance will exhaust its file descriptors in 4 hours. | warning | 10m |
-| FdExhaustion | This alert fires if, based on a linear prediction on file descriptors usage in the last 10 minutes, the instance will exhaust its file descriptors in one hour. | critical | 10m |
-| DeadMansSwitch | This is a DeadMansSwitch meant to ensure that the entire Alerting Pipeline is functional. | none |  |
+
+| Parameter      | Description                                                                                                                                                      | Severity | Interval |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| TargetDown     | This alert fires if more than 10% of the targets were down in the last 10 minutes.                                                                               | critical |   10m    |
+| FdExhaustion   | This alert fires if, based on a linear prediction on file descriptors usage in the last hour minutes, the instance will exhaust its file descriptors in 4 hours. | warning  |   10m    |
+| FdExhaustion   | This alert fires if, based on a linear prediction on file descriptors usage in the last 10 minutes, the instance will exhaust its file descriptors in one hour.  | critical |   10m    |
+| DeadMansSwitch | This is a DeadMansSwitch meant to ensure that the entire Alerting Pipeline is functional.                                                                        | none     |          |
 
 ### kubernetes-system
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| KubeNodeNotReady | This alert fires if a given node was not in Ready status in the last hour. | critical | 1h |
-| KubeVersionMismatch | This alert fires if the versions of the Kubernetes components were mismatching in the last hour. | warning | 1h |
-| KubeClientErrors | This alert fires if the Kubernetes API client error responses rate calculated in a 5 minutes window was more than 1% in the last 15 minutes. | warning | 15m |
-| KubeClientErrors | This alert fires if the Kubernetes API client error responses rate calculated in a 5 minutes window was more than 0.1 errors / sec in the last 15 minutes. | warning | 15m |
-| KubeletTooManyPods | This alert fires if a given kubelet is running more than 100 pods and is approaching the hard limit of 110 pods per node. | warning | 15m |
-| KubeAPILatencyHigh | This alert fires if the API server 99th percentile latency was more than 1 second in the last 10 minutes. | warning | 10m |
-| KubeAPILatencyHigh | This alert fires if the API server 99th percentile latency was more than 4 second in the last 10 minutes. | critical | 10m |
-| KubeAPIErrorsHigh | This alert fires if the requests error rate calculated in a 5 minutes window was more than 5% in the last 10 minutes. | critical | 10m |
+
+| Parameter           | Description                                                                                                                                                | Severity | Interval |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| KubeNodeNotReady    | This alert fires if a given node was not in Ready status in the last hour.                                                                                 | critical |    1h    |
+| KubeVersionMismatch | This alert fires if the versions of the Kubernetes components were mismatching in the last hour.                                                           | warning  |    1h    |
+| KubeClientErrors    | This alert fires if the Kubernetes API client error responses rate calculated in a 5 minutes window was more than 1% in the last 15 minutes.               | warning  |   15m    |
+| KubeClientErrors    | This alert fires if the Kubernetes API client error responses rate calculated in a 5 minutes window was more than 0.1 errors / sec in the last 15 minutes. | warning  |   15m    |
+| KubeletTooManyPods  | This alert fires if a given kubelet is running more than 100 pods and is approaching the hard limit of 110 pods per node.                                  | warning  |   15m    |
+| KubeAPILatencyHigh  | This alert fires if the API server 99th percentile latency was more than 1 second in the last 10 minutes.                                                  | warning  |   10m    |
+| KubeAPILatencyHigh  | This alert fires if the API server 99th percentile latency was more than 4 second in the last 10 minutes.                                                  | critical |   10m    |
+| KubeAPIErrorsHigh   | This alert fires if the requests error rate calculated in a 5 minutes window was more than 5% in the last 10 minutes.                                      | critical |   10m    |
 
 ### kubernetes-storage
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| KubePersistentVolumeStuck | This alert fires if a given persisten volume was stuck in the Pending or Failed phase in the last hour. | warning | 1h |
-| KubePersistentVolumeUsageCritical | This alert fires if the available space in a given PersistentVolumeClaim was less than 10% in the last minute. | critical | 1m |
-| KubePersistentVolumeFullInFourDays | This alert fires if, based on a linear prediction on the volume usage in the last 6 hours, the volume will be full in four days. | warning | 5m |
-| KubePersistentVolumeInodeUsageCritical | This alert fires if the available inodes in a given PersistentVolumeClaim were less than 10% in the last minute. | critical | 1m |
-| KubePersistentVolumeInodeFullInFourDays | This alert fires if, based on a linear prediction on the inodes usage in the last 6 hours, the volume will exhaust its inodes in four days. | warning | 5m |
+
+| Parameter                               | Description                                                                                                                                 | Severity | Interval |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| KubePersistentVolumeStuck               | This alert fires if a given persisten volume was stuck in the Pending or Failed phase in the last hour.                                     | warning  |    1h    |
+| KubePersistentVolumeUsageCritical       | This alert fires if the available space in a given PersistentVolumeClaim was less than 10% in the last minute.                              | critical |    1m    |
+| KubePersistentVolumeFullInFourDays      | This alert fires if, based on a linear prediction on the volume usage in the last 6 hours, the volume will be full in four days.            | warning  |    5m    |
+| KubePersistentVolumeInodeUsageCritical  | This alert fires if the available inodes in a given PersistentVolumeClaim were less than 10% in the last minute.                            | critical |    1m    |
+| KubePersistentVolumeInodeFullInFourDays | This alert fires if, based on a linear prediction on the inodes usage in the last 6 hours, the volume will exhaust its inodes in four days. | warning  |    5m    |
 
 ### kubernetes-absent
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| AlertmanagerDown | This alert fires if Prometheus target discovery was not able to reach AlertManager in the last 15 minutes. | critical | 15m |
-| KubeAPIDown | This alert fires if Prometheus target discovery was not able to reach kube-apiserver in the last 15 minutes. | critical | 15m |
-| KubeStateMetricsDown | This alert fires if Prometheus target discovery was not able to reach kube-state-metrics in the last 15 minutes. | critical | 15m |
-| KubeletDown | This alert fires if Prometheus target discovery was not able to reach the kubelet in the last 15 minutes. | critical | 15m |
-| NodeExporterDown | This alert fires if Prometheus target discovery was not able to reach node-exporter in the last 15 minutes. | critical | 15m |
-| PrometheusDown | This alert fires if Prometheus target discovery was not able to reach Prometheus in the last 15 minutes. | critical | 15m |
-| PrometheusOperatorDown | This alert fires if Prometheus target discovery was not able to reach the Prometheus Operator in the last 15 minutes. | critical | 15m |
+
+| Parameter              | Description                                                                                                           | Severity | Interval |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| AlertmanagerDown       | This alert fires if Prometheus target discovery was not able to reach AlertManager in the last 15 minutes.            | critical |   15m    |
+| KubeAPIDown            | This alert fires if Prometheus target discovery was not able to reach kube-apiserver in the last 15 minutes.          | critical |   15m    |
+| KubeStateMetricsDown   | This alert fires if Prometheus target discovery was not able to reach kube-state-metrics in the last 15 minutes.      | critical |   15m    |
+| KubeletDown            | This alert fires if Prometheus target discovery was not able to reach the kubelet in the last 15 minutes.             | critical |   15m    |
+| NodeExporterDown       | This alert fires if Prometheus target discovery was not able to reach node-exporter in the last 15 minutes.           | critical |   15m    |
+| PrometheusDown         | This alert fires if Prometheus target discovery was not able to reach Prometheus in the last 15 minutes.              | critical |   15m    |
+| PrometheusOperatorDown | This alert fires if Prometheus target discovery was not able to reach the Prometheus Operator in the last 15 minutes. | critical |   15m    |
 
 ### alertmanager
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| AlertmanagerConfigInconsistent | This alert fires if the configuration of the instances of the Alertmanager cluster were out of sync in the last 5 minutes. | critical | 5m |
-| AlertmanagerDownOrMissing | This alert fires if in the last 5 minutes an unexpected number of Alertmanagers were scraped or Alertmanagers disappered from target discovery. | critical | 5m |
-| AlertmanagerFailedReload | This alert fires if the Alertmanager's configuration reload failed in the last 10 minutes. | critical | 10m |
+
+| Parameter                      | Description                                                                                                                                     | Severity | Interval |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| AlertmanagerConfigInconsistent | This alert fires if the configuration of the instances of the Alertmanager cluster were out of sync in the last 5 minutes.                      | critical |    5m    |
+| AlertmanagerDownOrMissing      | This alert fires if in the last 5 minutes an unexpected number of Alertmanagers were scraped or Alertmanagers disappered from target discovery. | critical |    5m    |
+| AlertmanagerFailedReload       | This alert fires if the Alertmanager's configuration reload failed in the last 10 minutes.                                                      | critical |   10m    |
 
 ### kubernetes-resources
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| KubeCPUOvercommit | This alert fires if the cluster-wide CPU requests from pods in the last 5 minutes were so high to not tolerate a node failure. | warning | 5m |
-| KubeMemOvercommit | This alert fires if the cluster-wide memory requests from pods in the last 5 minutes were so high to not tolerate a node failure. | warning | 5m |
-| KubeCPUOvercommit | This alert fires if the hard limit of CPU resources quota in the last 5 minutes is more than 150% of the available resources, i.e. the hard limit is set too high. | warning | 5m |
-| KubeMemOvercommit | This alert fires if the hard limit of memory resources quota in the last 5 minutes is more than 150% of the available resources, i.e. the hard limit is set too high. | warning | 5m |
-| KubeQuotaExceeded | This alert fires if a given resource was used for more than 90% of the corresponding hard quota in the last 15 minutes. | warning | 15m |
+
+| Parameter         | Description                                                                                                                                                           | Severity | Interval |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
+| KubeCPUOvercommit | This alert fires if the cluster-wide CPU requests from pods in the last 5 minutes were so high to not tolerate a node failure.                                        | warning  |    5m    |
+| KubeMemOvercommit | This alert fires if the cluster-wide memory requests from pods in the last 5 minutes were so high to not tolerate a node failure.                                     | warning  |    5m    |
+| KubeCPUOvercommit | This alert fires if the hard limit of CPU resources quota in the last 5 minutes is more than 150% of the available resources, i.e. the hard limit is set too high.    | warning  |    5m    |
+| KubeMemOvercommit | This alert fires if the hard limit of memory resources quota in the last 5 minutes is more than 150% of the available resources, i.e. the hard limit is set too high. | warning  |    5m    |
+| KubeQuotaExceeded | This alert fires if a given resource was used for more than 90% of the corresponding hard quota in the last 15 minutes.                                               | warning  |   15m    |
 
 <!-- Links -->
 

--- a/katalog/prometheus-operated/dashboards/kustomization.yaml
+++ b/katalog/prometheus-operated/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: monitoring
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Monitoring"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/thanos/base/components/dashboards/kustomization.yaml
+++ b/katalog/thanos/base/components/dashboards/kustomization.yaml
@@ -9,6 +9,8 @@ kind: Kustomization
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Monitoring"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/x509-exporter/common/dashboards/kustomization.yaml
+++ b/katalog/x509-exporter/common/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: monitoring
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Monitoring"
   disableNameSuffixHash: true
 
 configMapGenerator:


### PR DESCRIPTION
### Intro

With the number of Grafana dashboards that get deployed by default with KFD, a flat structure is not working anymore.

Grafana allows to organize the dashboards in folders. Making the discovery of dashboards easier and lowering the visual load on the user.

This PR is an attempt to improve the UX in Grafana by dynamically generating the folder structure. We are already using dynamic discovery of dashboards by loading all the configmaps that have the `grafana-sighup-dashboard` label. This PR adds logic and configuration to use the value of the `grafana-folder` configmap **annotation** to put the dashboards included in the folder defined by the annotation value.

Grafana will generate automatically the folder if it does not exist. If the annotation is not present, the dashboards will end up in the "General" folder.

### Summary
- Add dynamic dashboards folder generation in Grafana. Now configmaps with the `grafana-folder` annotation will be put inside the specified folder from the annotation's value. This folder structure will be reflcted by Grafana in the UI.
- Added the annotation to all the included dashboards in the monitoring module.
- Update maintenance guide.
- Update docs.

### Before
<img width="1486" alt="SCR-20230414-nfux" src="https://user-images.githubusercontent.com/6362698/232065133-5e149dc4-a5f4-4f3d-b4ef-807bcc6b7b7f.png">


### After
<img width="1488" alt="image" src="https://user-images.githubusercontent.com/6362698/232065011-3a030911-df9b-47b7-a8c9-a60ddf13f694.png">


> **Note** we'll need to add the annotation to the dashboards created by other modules if we want them to be in a specific folder, for example, put the NGINX dashboard in the 'Ingress' folder.

closes #154 