### PR TITLE
feat: add resources in order to delivery aggregated metrics for hpa t…

### DIFF
--- a/katalog/prometheus-adapter/apiService.yaml
+++ b/katalog/prometheus-adapter/apiService.yaml
@@ -20,3 +20,60 @@ spec:
     namespace: monitoring
   version: v1beta1
   versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.10.0
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: prometheus-adapter
+    namespace: monitoring
+  version: v1beta1
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.10.0
+  name: v1beta2.custom.metrics.k8s.io
+spec:
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: prometheus-adapter
+    namespace: monitoring
+  version: v1beta2
+  versionPriority: 200
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.10.0
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  group: external.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: prometheus-adapter
+    namespace: monitoring
+  version: v1beta1
+  versionPriority: 100

--- a/katalog/prometheus-adapter/clusterRoleBindingHpaController.yaml
+++ b/katalog/prometheus-adapter/clusterRoleBindingHpaController.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-prometheus-adapter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: resource-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system

--- a/katalog/prometheus-adapter/clusterRoleServerResources.yaml
+++ b/katalog/prometheus-adapter/clusterRoleServerResources.yaml
@@ -15,6 +15,8 @@ metadata:
 rules:
 - apiGroups:
   - metrics.k8s.io
+  - custom.metrics.k8s.io
+  - external.metrics.k8s.io
   resources:
   - '*'
   verbs:

--- a/katalog/prometheus-adapter/configMap.yaml
+++ b/katalog/prometheus-adapter/configMap.yaml
@@ -5,6 +5,71 @@
 apiVersion: v1
 data:
   config.yaml: |-
+    rules:
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters: []
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_seconds_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)$
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_total$
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ""
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_seconds_total
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters: []
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
     "resourceRules":
       "cpu":
         "containerLabel": "container"
@@ -62,6 +127,25 @@ data:
             "pod":
               "resource": "pod"
       "window": "5m"
+    externalRules:
+    - seriesQuery: '{__name__=~"^.*_queue_(length|size)$",namespace!=""}'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+      name:
+        matches: ^.*_queue_(length|size)$
+        as: "$0"
+      metricsQuery: max(<<.Series>>{<<.LabelMatchers>>})
+    - seriesQuery: '{__name__=~"^.*_queue$",namespace!=""}'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+      name:
+        matches: ^.*_queue$
+        as: "$0"
+      metricsQuery: max(<<.Series>>{<<.LabelMatchers>>})
 kind: ConfigMap
 metadata:
   labels:

--- a/katalog/prometheus-adapter/kustomization.yaml
+++ b/katalog/prometheus-adapter/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - apiService.yaml
   - clusterRole.yaml
   - clusterRoleAggregatedMetricsReader.yaml
+  - clusterRoleBindingHpaController.yaml
   - clusterRoleBinding.yaml
   - clusterRoleBindingDelegator.yaml
   - clusterRoleServerResources.yaml


### PR DESCRIPTION
this is a possible solution that gets the aggregated metrics

Feature:
add apiService for custom and external metrics 
add clusterRoleBindingHpaController.yaml for horizontal-pod-autoscaler authorization
add in configmap seriesQuery and externalRules based on [sample-config.yaml]( https://github.com/kubernetes-sigs/prometheus-adapter/blob/master/docs/sample-config.yaml)