### PR TITLE
feat(grafana): added a custom Grafana dashboard

### DIFF
--- a/katalog/grafana/MAINTENANCE.md
+++ b/katalog/grafana/MAINTENANCE.md
@@ -21,3 +21,4 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
 - We've changed the json file inside grafana-dashboardSources, dropping the folder name and enbling the option to use subfolders.
 - Added `FOLDER_ANNOTATION` environment variable to the dashboards sidecar.
+- Added custom grafana dashboard (`fury-cluster-overview.json`), which shows an overview of the status of the resources present in the cluster.

--- a/katalog/grafana/dashboards/fury-cluster-overview.json
+++ b/katalog/grafana/dashboards/fury-cluster-overview.json
@@ -1,4367 +1,4467 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "$$hashKey": "object:173",
-          "builtIn": 1,
-          "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:173",
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
           "type": "dashboard"
-        }
-      ]
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 12202,
+  "graphTooltip": 0,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [
+        "kubernetes-mixin"
+      ],
+      "targetBlank": false,
+      "title": "Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 82,
+      "panels": [],
+      "title": "Cluster Overview",
+      "type": "row"
     },
-    "description": "",
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "gnetId": 12202,
-    "graphTooltip": 0,
-    "links": [
-      {
-        "asDropdown": true,
-        "icon": "external link",
-        "includeVars": false,
-        "keepTime": false,
-        "tags": [
-          "kubernetes-mixin"
-        ],
-        "targetBlank": false,
-        "title": "Dashboards",
-        "tooltip": "",
-        "type": "dashboards",
-        "url": ""
-      }
-    ],
-    "liveNow": false,
-    "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 82,
-        "panels": [],
-        "title": "Cluster Status",
-        "type": "row"
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
       },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 4,
-          "x": 0,
-          "y": 1
-        },
-        "id": 93,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": "count(kube_node_info{cluster=\"$cluster\", node=~\"$node\"})",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Total Nodes",
-        "transformations": [],
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 3,
-          "x": 4,
-          "y": 1
-        },
-        "id": 90,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "background",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": "count(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}==0)",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Healthy Nodes",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 4,
-          "x": 10,
-          "y": 1
-        },
-        "id": 94,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": "count(kube_namespace_created)",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Total Namespace",
-        "transformations": [],
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "rgb(31, 120, 193)",
-              "mode": "fixed"
-            },
-            "mappings": [
+                "color": "green",
+                "value": null
+              },
               {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
+                "color": "red",
+                "value": 80
               }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 2,
-          "x": 14,
-          "y": 1
-        },
-        "id": 98,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": " count(count by (pod)(container_spec_memory_reservation_limit_bytes{pod!=\"\", node=~\"$node\", namespace=~\"$namespace\"}))",
-            "hide": false,
-            "instant": false,
-            "legendFormat": "{{pod}}",
-            "refId": "A"
+            ]
           }
-        ],
-        "title": "Total pods",
-        "transparent": true,
-        "type": "stat"
+        },
+        "overrides": []
       },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "#299c46",
-                  "value": null
-                },
-                {
-                  "color": "#37872D",
-                  "value": 0
-                },
-                {
-                  "color": "#d44a3a"
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 2,
-          "x": 16,
-          "y": 1
-        },
-        "id": 100,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": "count(kube_persistentvolumeclaim_info{namespace=~\"$namespace\"}) ",
-            "hide": false,
-            "instant": false,
-            "legendFormat": "{{pod}}",
-            "refId": "A"
-          }
-        ],
-        "title": "PVCs",
-        "transparent": true,
-        "type": "stat"
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 0,
+        "y": 1
       },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "#299c46",
-                  "value": null
-                },
-                {
-                  "color": "#37872D",
-                  "value": 0
-                },
-                {
-                  "color": "#d44a3a",
-                  "value": 1
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 18,
-          "y": 1
-        },
-        "id": 104,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": "count(kube_pod_container_status_terminated_reason{reason!=\"Completed\", namespace=~\"$namespace\"} !=0 ) or vector(0)",
-            "hide": false,
-            "instant": false,
-            "legendFormat": "{{pod}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Terminated pods",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "#299c46",
-                  "value": null
-                },
-                {
-                  "color": "#37872D",
-                  "value": 0
-                },
-                {
-                  "color": "#d44a3a",
-                  "value": 1
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 21,
-          "y": 1
-        },
-        "id": 102,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": "count(kube_pod_container_status_waiting{namespace=~\"$namespace\"} !=0 ) or vector(0)",
-            "hide": false,
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{pod}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Waiting pods",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "P1809F7CD0C75ACF3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
-                },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "dark-red",
-                  "value": 1
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 3,
-          "x": 4,
-          "y": 3
-        },
-        "id": 91,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "background",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.3.2",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "editorMode": "code",
-            "expr": "count(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}!=0) OR on() vector(0)",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Unhealthy Nodes",
-        "type": "stat"
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$datasource"
-        },
-        "fill": 10,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 0,
-          "y": 5
-        },
-        "hiddenSeries": false,
-        "id": 108,
-        "interval": "1m",
-        "legend": {
-          "alignAsTable": true,
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "rightSide": true,
-          "show": true,
-          "total": false,
+      "id": 93,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
           "values": false
         },
-        "lines": true,
-        "linewidth": 0,
-        "links": [],
-        "nullPointMode": "null as zero",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "9.3.2",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "editorMode": "code",
-            "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\", namespace=~\"$namespace\"}) by (namespace)",
-            "format": "time_series",
-            "intervalFactor": 2,
-            "legendFormat": "{{namespace}}",
-            "range": true,
-            "refId": "A",
-            "step": 10
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "CPU Usage",
-        "tooltip": {
-          "shared": false,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "logBase": 1,
-            "min": 0,
-            "show": true
-          },
-          {
-            "format": "short",
-            "logBase": 1,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
+        "textMode": "auto"
       },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$datasource"
-        },
-        "fill": 10,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 12,
-          "y": 5
-        },
-        "hiddenSeries": false,
-        "id": 110,
-        "interval": "1m",
-        "legend": {
-          "alignAsTable": true,
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "rightSide": true,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 0,
-        "links": [],
-        "nullPointMode": "null as zero",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "9.3.2",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "$datasource"
-            },
-            "editorMode": "code",
-            "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\",node=~\"$node\", namespace=~\"$namespace\"}) by (namespace)",
-            "format": "time_series",
-            "intervalFactor": 2,
-            "legendFormat": "{{namespace}}",
-            "range": true,
-            "refId": "A",
-            "step": 10
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "Memory Usage (w/o cache)",
-        "tooltip": {
-          "shared": false,
-          "sort": 2,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "bytes",
-            "logBase": 1,
-            "min": 0,
-            "show": true
-          },
-          {
-            "format": "short",
-            "logBase": 1,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 12
-        },
-        "id": 113,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "left",
-                  "displayMode": "auto",
-                  "filterable": true,
-                  "inspect": false
-                },
-                "mappings": [],
-                "noValue": "-",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Value #memory_used"
-                  },
-                  "properties": [
-                    {
-                      "id": "unit",
-                      "value": "bytes"
-                    },
-                    {
-                      "id": "decimals",
-                      "value": 2
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Value #memory_requests"
-                  },
-                  "properties": [
-                    {
-                      "id": "unit",
-                      "value": "bytes"
-                    },
-                    {
-                      "id": "decimals",
-                      "value": 2
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Value #memory_limits"
-                  },
-                  "properties": [
-                    {
-                      "id": "unit",
-                      "value": "bytes"
-                    },
-                    {
-                      "id": "decimals",
-                      "value": 2
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Node"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 250
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "",
-                          "url": "/d/JzmufwUVz/node-exporter-nodes?var-datasource=$datasource&var-instance=${__data.fields.node}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 115
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "",
-                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Pod"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 226
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "",
-                          "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod\"]}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Node Status"
-                  },
-                  "properties": [
-                    {
-                      "id": "mappings",
-                      "value": [
-                        {
-                          "options": {
-                            "0": {
-                              "color": "green",
-                              "index": 1,
-                              "text": "Up"
-                            },
-                            "1": {
-                              "color": "red",
-                              "index": 0,
-                              "text": "Down"
-                            }
-                          },
-                          "type": "value"
-                        }
-                      ]
-                    },
-                    {
-                      "id": "custom.displayMode",
-                      "value": "color-text"
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 11,
-              "w": 24,
-              "x": 0,
-              "y": 13
-            },
-            "id": 118,
-            "links": [],
-            "options": {
-              "footer": {
-                "enablePagination": true,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": true
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "max(kube_pod_container_resource_requests{resource=\"memory\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "intervalFactor": 1,
-                "refId": "memory_requests"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "max(kube_pod_container_resource_limits{resource=\"memory\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
-                "format": "table",
-                "instant": true,
-                "intervalFactor": 1,
-                "refId": "memory_limits"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "max(container_memory_working_set_bytes{name!=\"\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "intervalFactor": 1,
-                "legendFormat": "",
-                "refId": "memory_used"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "max(kube_pod_container_resource_requests{resource=\"cpu\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "intervalFactor": 1,
-                "refId": "cpu_requests"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "max(kube_pod_container_resource_limits{resource=\"cpu\"}) by (pod)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "intervalFactor": 1,
-                "refId": "cpu_limits"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\", container_name!=\"POD\"}[5m])) by (pod)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "intervalFactor": 1,
-                "legendFormat": "",
-                "refId": "cpu_used"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "exemplar": false,
-                "expr": "max(kube_pod_info) by (pod,namespace,node)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "legendFormat": "__auto",
-                "range": false,
-                "refId": "pod_info"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "exemplar": false,
-                "expr": "sum(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}!=0) by (node) or sum(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}==0) by (node)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "legendFormat": "",
-                "range": false,
-                "refId": "node_status"
-              }
-            ],
-            "title": "Memory usage per container",
-            "transformations": [
-              {
-                "id": "merge",
-                "options": {
-                  "reducers": []
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "Value #A": true,
-                    "Value #pod_info": true,
-                    "namespace": false,
-                    "pod": false
-                  },
-                  "indexByName": {
-                    "Time": 10,
-                    "Value #cpu_limits": 9,
-                    "Value #cpu_requests": 8,
-                    "Value #cpu_used": 7,
-                    "Value #memory_limits": 6,
-                    "Value #memory_requests": 5,
-                    "Value #memory_used": 4,
-                    "Value #node_status": 3,
-                    "Value #pod_info": 11,
-                    "namespace": 1,
-                    "node": 2,
-                    "pod": 0
-                  },
-                  "renameByName": {
-                    "Value #cpu_limits": "CPU Limits",
-                    "Value #cpu_requests": "CPU Requests",
-                    "Value #cpu_used": "CPU Used",
-                    "Value #memory_limits": "RAM Limits ",
-                    "Value #memory_requests": "RAM Requests",
-                    "Value #memory_used": "RAM Used",
-                    "Value #node_status": "Node Status",
-                    "namespace": "Namespace",
-                    "node": "Node",
-                    "pod": "Pod"
-                  }
-                }
-              },
-              {
-                "id": "filterByValue",
-                "options": {
-                  "filters": [
-                    {
-                      "config": {
-                        "id": "isNotNull",
-                        "options": {}
-                      },
-                      "fieldName": "Node Status"
-                    }
-                  ],
-                  "match": "any",
-                  "type": "include"
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Node Status",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 13
-        },
-        "id": 31,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "decimals": 0,
-                "mappings": [],
-                "unit": "short"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Failed"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "red",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Running"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "green",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 4,
-              "x": 0,
-              "y": 30
-            },
-            "id": 24,
-            "links": [],
-            "maxDataPoints": 3,
-            "options": {
-              "displayLabels": [],
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "right",
-                "showLegend": true,
-                "values": [
-                  "percent"
-                ]
-              },
-              "pieType": "donut",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_number_unavailable{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_number_available{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Running",
-                "range": true,
-                "refId": "B"
-              }
-            ],
-            "title": "Daemon Sets",
-            "transformations": [],
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "decimals": 0,
-                "mappings": [],
-                "unit": "short"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Running"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "green",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Failed"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "red",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 4,
-              "x": 4,
-              "y": 30
-            },
-            "id": 25,
-            "links": [],
-            "maxDataPoints": 3,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "right",
-                "showLegend": true,
-                "values": [
-                  "percent"
-                ]
-              },
-              "pieType": "donut",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "count(kube_deployment_created{namespace=~\"$namespace\"}) - count(kube_deployment_status_replicas_available{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "count(kube_deployment_created{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Running",
-                "range": true,
-                "refId": "B"
-              }
-            ],
-            "title": "Deployments",
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "decimals": 0,
-                "mappings": [],
-                "unit": "short"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Failed"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "red",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 4,
-              "x": 8,
-              "y": 30
-            },
-            "id": 26,
-            "links": [],
-            "maxDataPoints": 3,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "right",
-                "showLegend": true,
-                "values": [
-                  "percent"
-                ]
-              },
-              "pieType": "donut",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_job_status_succeeded{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Succeeded",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_job_status_failed{namespace=~\"$namespace\"})",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "B"
-              }
-            ],
-            "title": "Jobs",
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "decimals": 0,
-                "mappings": [],
-                "unit": "short"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Running"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "green",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Failed"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "red",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 4,
-              "x": 12,
-              "y": 30
-            },
-            "id": 57,
-            "links": [],
-            "maxDataPoints": 3,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "right",
-                "showLegend": true,
-                "values": [
-                  "percent"
-                ]
-              },
-              "pieType": "donut",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_pod_status_phase{phase!=\"Running\", namespace=~\"$namespace\"} and kube_pod_status_phase{phase!=\"Succeeded\", namespace=~\"$namespace\"}) OR on() vector(0)",
-                "interval": "",
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_pod_status_phase{phase=\"Running\", namespace=~\"$namespace\"} or kube_pod_status_phase{phase=\"Succeeded\", namespace=~\"$namespace\"})",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Running",
-                "range": true,
-                "refId": "B"
-              }
-            ],
-            "title": "Pods",
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "decimals": 0,
-                "mappings": [],
-                "unit": "short"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Running"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "green",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Failed"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "red",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 4,
-              "x": 16,
-              "y": 30
-            },
-            "id": 27,
-            "links": [],
-            "maxDataPoints": 3,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "right",
-                "showLegend": true,
-                "values": [
-                  "percent"
-                ]
-              },
-              "pieType": "donut",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "count(kube_replicaset_created{namespace=~\"$namespace\"}) - count(kube_replicaset_status_ready_replicas{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "count(kube_replicaset_created{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Running",
-                "range": true,
-                "refId": "B"
-              }
-            ],
-            "title": "Replica Sets",
-            "type": "piechart"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  }
-                },
-                "decimals": 0,
-                "mappings": [],
-                "unit": "short"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Running"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "green",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Failed"
-                  },
-                  "properties": [
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "red",
-                        "mode": "fixed"
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 6,
-              "w": 4,
-              "x": 20,
-              "y": 30
-            },
-            "id": 29,
-            "links": [],
-            "maxDataPoints": 3,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "right",
-                "showLegend": true,
-                "values": [
-                  "percent"
-                ]
-              },
-              "pieType": "donut",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "tooltip": {
-                "mode": "single",
-                "sort": "none"
-              }
-            },
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "count(kube_statefulset_created{namespace=~\"$namespace\"}) - count(kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "count(kube_statefulset_created{namespace=~\"$namespace\"})",
-                "interval": "",
-                "legendFormat": "Running",
-                "range": true,
-                "refId": "B"
-              }
-            ],
-            "title": "Stateful Sets",
-            "type": "piechart"
-          }
-        ],
-        "title": "Workload Status",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 14
-        },
-        "id": 59,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "fixedColor": "#629e51",
-                  "mode": "fixed"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": true,
-                  "inspect": false
-                },
-                "mappings": [
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 177
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 15
-            },
-            "id": 111,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-              "footer": {
-                "enablePagination": true,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": true
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_number_available{namespace=~\"$namespace\"}) by (namespace,daemonset)",
-                "format": "table",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Available",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_desired_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Desired",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_current_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Current",
-                "range": true,
-                "refId": "C"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_number_ready{namespace=~\"$namespace\"}) by (namespace,daemonset)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Ready",
-                "range": true,
-                "refId": "D"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_updated_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Up-To-Date",
-                "range": true,
-                "refId": "E"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_daemonset_status_number_unavailable{namespace=~\"$namespace\"}) by (namespace,daemonset)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Unavailable",
-                "range": true,
-                "refId": "F"
-              }
-            ],
-            "title": "Deamon Sets Status",
-            "transformations": [
-              {
-                "id": "merge",
-                "options": {}
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {
-                    "Time": 0,
-                    "Value #A": 4,
-                    "Value #B": 5,
-                    "Value #C": 6,
-                    "container": 3,
-                    "daemonset": 2,
-                    "namespace": 1
-                  },
-                  "renameByName": {
-                    "Value #A": "Available",
-                    "Value #B": "Desired",
-                    "Value #C": "Current",
-                    "Value #D": "Ready",
-                    "Value #E": "Up-To-Date",
-                    "Value #F": "Unavailable",
-                    "container": "Container",
-                    "daemonset": "Deamonset",
-                    "namespace": "Namespace"
-                  }
-                }
-              },
-              {
-                "id": "groupBy",
-                "options": {
-                  "fields": {
-                    "Available": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Container": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Current": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Daemonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Deamonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Desired": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod Name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pods": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Ready": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Unavailable": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Up-To-Date": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #A": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #B": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #C": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "container": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "daemonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    }
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Daemon Sets",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 15
-        },
-        "id": 63,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "fixedColor": "#629e51",
-                  "mode": "fixed"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": true,
-                  "inspect": false
-                },
-                "mappings": [
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 177
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 16
-            },
-            "id": 64,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-              "footer": {
-                "enablePagination": true,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": true
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) by (namespace,deployment)",
-                "format": "table",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Available",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_deployment_status_replicas_ready{namespace=~\"$namespace\"}) by (namespace,deployment)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "{{label_name}}",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_deployment_status_replicas_updated{namespace=~\"$namespace\"}) by (namespace,deployment)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Up-To-Date",
-                "range": true,
-                "refId": "C"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_deployment_status_replicas_unavailable) by (namespace,deployment)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Unavailable",
-                "range": true,
-                "refId": "D"
-              }
-            ],
-            "title": "Deployments Status",
-            "transformations": [
-              {
-                "id": "merge",
-                "options": {}
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {
-                    "Time": 0,
-                    "Value": 4,
-                    "container": 3,
-                    "deployment": 2,
-                    "namespace": 1
-                  },
-                  "renameByName": {
-                    "Value": "Available",
-                    "Value #A": "Available",
-                    "Value #B": "Ready",
-                    "Value #C": "Up-To-Date",
-                    "Value #D": "Unavailable",
-                    "container": "Container",
-                    "deployment": "Deployment",
-                    "namespace": "Namespace"
-                  }
-                }
-              },
-              {
-                "id": "groupBy",
-                "options": {
-                  "fields": {
-                    "Available": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Container": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Current": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Daemonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Deamonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Deployment": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Desired": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod Name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pods": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Ready": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Time": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Unavailable": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Up-To-Date": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #A": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #B": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #C": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "container": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "daemonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "deployment": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    }
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Deployments",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 16
-        },
-        "id": 37,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "fixedColor": "#629e51",
-                  "mode": "fixed"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": true,
-                  "inspect": false
-                },
-                "mappings": [
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 177
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 17
-            },
-            "id": 65,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-              "footer": {
-                "enablePagination": true,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": true
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_job_status_active{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Active",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_job_status_succeeded{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Succeeded",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_job_status_failed{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "C"
-              }
-            ],
-            "title": "Jobs Status",
-            "transformations": [
-              {
-                "id": "merge",
-                "options": {}
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {
-                    "Time": 0,
-                    "Value": 4,
-                    "job": 2,
-                    "job_name": 3,
-                    "namespace": 1
-                  },
-                  "renameByName": {
-                    "Value": "Active",
-                    "Value #A": "Active",
-                    "Value #B": "Succeeded",
-                    "Value #C": "Failed",
-                    "container": "",
-                    "job": "Job",
-                    "job_name": "Job Name",
-                    "namespace": "Namespace"
-                  }
-                }
-              },
-              {
-                "id": "groupBy",
-                "options": {
-                  "fields": {
-                    "Active": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Available": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Container": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Current": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Daemonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Deamonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Deployment": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Desired": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Failed": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Job": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Job Name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod Name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pods": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Ready": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Succeeded": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Time": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Unavailable": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Up-To-Date": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #A": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #B": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #C": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "container": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "daemonset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "deployment": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "job": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "job_name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    }
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Jobs",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 17
-        },
-        "id": 33,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "fixedColor": "#629e51",
-                  "mode": "fixed"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": true,
-                  "inspect": false
-                },
-                "mappings": [
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 256
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Pod"
-                  },
-                  "properties": [
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod\"]}"
-                        }
-                      ]
-                    },
-                    {
-                      "id": "custom.width",
-                      "value": 427
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 24,
-              "x": 0,
-              "y": 18
-            },
-            "id": 30,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-              "footer": {
-                "enablePagination": true,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": true
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_pod_status_phase{phase=\"Running\", namespace=~\"$namespace\"}) by (namespace, pod)",
-                "format": "table",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Running",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_pod_status_phase{phase=\"Failed\", namespace=~\"$namespace\"}) by (namespace, pod)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Failed",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_pod_status_phase{phase=\"Pending\", namespace=~\"$namespace\"}) by (namespace, pod)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Pending",
-                "range": true,
-                "refId": "C"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_pod_status_phase{phase=\"Succeeded\", namespace=~\"$namespace\"}) by (namespace, pod)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Succeeded",
-                "range": true,
-                "refId": "D"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_pod_status_phase{phase=\"Unknown\", namespace=~\"$namespace\"}) by (namespace, pod)",
-                "format": "table",
-                "hide": false,
-                "legendFormat": "Unknown",
-                "range": true,
-                "refId": "E"
-              }
-            ],
-            "title": "Pods Status",
-            "transformations": [
-              {
-                "id": "merge",
-                "options": {}
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {
-                    "Time": 0,
-                    "Value #A": 3,
-                    "Value #B": 4,
-                    "namespace": 1,
-                    "pod": 2
-                  },
-                  "renameByName": {
-                    "Time": "",
-                    "Value": "",
-                    "Value #A": "Running",
-                    "Value #B": "Failed",
-                    "Value #C": "Pending",
-                    "Value #D": "Succeeded",
-                    "Value #E": "Unknown",
-                    "namespace": "Namespace",
-                    "pod": "Pod"
-                  }
-                }
-              },
-              {
-                "id": "groupBy",
-                "options": {
-                  "fields": {
-                    "Failed": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pending": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod Name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pods": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Running": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Succeeded": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Time": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Unknown": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #A": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #B": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    }
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Pods",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 18
-        },
-        "id": 67,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "fixedColor": "#629e51",
-                  "mode": "fixed"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": true,
-                  "inspect": false
-                },
-                "mappings": [
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 256
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 24,
-              "x": 0,
-              "y": 19
-            },
-            "id": 68,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-              "footer": {
-                "enablePagination": true,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": true
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_replicaset_status_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
-                "format": "table",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Current",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_replicaset_status_ready_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Ready",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_replicaset_spec_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Desired",
-                "range": true,
-                "refId": "C"
-              }
-            ],
-            "title": "Replica Sets Status",
-            "transformations": [
-              {
-                "id": "merge",
-                "options": {}
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {
-                    "Time": 0,
-                    "Value #A": 3,
-                    "Value #B": 4,
-                    "Value #C": 5,
-                    "namespace": 1,
-                    "replicaset": 2
-                  },
-                  "renameByName": {
-                    "Time": "",
-                    "Value": "",
-                    "Value #A": "Current",
-                    "Value #B": "Ready",
-                    "Value #C": "Desired",
-                    "Value #D": "Succeeded",
-                    "Value #E": "Unknown",
-                    "namespace": "Namespace",
-                    "pod": "Pod",
-                    "replicaset": "Replica Sets"
-                  }
-                }
-              },
-              {
-                "id": "groupBy",
-                "options": {
-                  "fields": {
-                    "Current": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Desired": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Failed": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pending": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod Name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pods": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Ready": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Replica Sets": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Running": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Succeeded": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Time": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Unknown": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #A": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #B": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "replicaset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    }
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Replica Sets",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 19
-        },
-        "id": 70,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "fixedColor": "#629e51",
-                  "mode": "fixed"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": true,
-                  "inspect": false
-                },
-                "mappings": [
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 256
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Pod"
-                  },
-                  "properties": [
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "Drill down",
-                          "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod Name\"]}"
-                        }
-                      ]
-                    },
-                    {
-                      "id": "custom.width",
-                      "value": 427
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 10,
-              "w": 24,
-              "x": 0,
-              "y": 20
-            },
-            "id": 71,
-            "links": [],
-            "maxDataPoints": 100,
-            "options": {
-              "footer": {
-                "enablePagination": true,
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": true
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_statefulset_status_replicas_current{namespace=~\"$namespace\"}) by (namespace, statefulset)",
-                "format": "table",
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Current",
-                "range": true,
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) by (namespace, statefulset)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Ready",
-                "range": true,
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_statefulset_replicas{namespace=~\"$namespace\"}) by (namespace, statefulset)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Desired",
-                "range": true,
-                "refId": "C"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_statefulset_status_replicas_available) by (namespace, statefulset)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Available",
-                "range": true,
-                "refId": "D"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_statefulset_status_replicas_updated) by (namespace, statefulset)",
-                "format": "table",
-                "hide": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "Updated",
-                "range": true,
-                "refId": "E"
-              }
-            ],
-            "title": "Stateful Sets Status",
-            "transformations": [
-              {
-                "id": "merge",
-                "options": {}
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {
-                    "Time": 0,
-                    "Value #A": 3,
-                    "Value #B": 4,
-                    "Value #C": 5,
-                    "Value #D": 6,
-                    "Value #E": 7,
-                    "namespace": 1,
-                    "statefulset": 2
-                  },
-                  "renameByName": {
-                    "Time": "",
-                    "Value": "",
-                    "Value #A": "Current",
-                    "Value #B": "Ready",
-                    "Value #C": "Desired",
-                    "Value #D": "Available",
-                    "Value #E": "Updated",
-                    "namespace": "Namespace",
-                    "pod": "Pod",
-                    "replicaset": "Replica Sets",
-                    "statefulset": "StatefulSet"
-                  }
-                }
-              },
-              {
-                "id": "groupBy",
-                "options": {
-                  "fields": {
-                    "Available": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Current": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Desired": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Failed": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pending": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pod Name": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Pods": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Ready": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Replica Sets": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Running": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "StatefulSet": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Succeeded": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Time": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Unknown": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Updated": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #A": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "Value #B": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "namespace": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "pod": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    },
-                    "replicaset": {
-                      "aggregations": [],
-                      "operation": "groupby"
-                    }
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Stateful Sets",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 20
-        },
-        "id": 115,
-        "panels": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "P1809F7CD0C75ACF3"
-            },
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false,
-                  "inspect": false
-                },
-                "mappings": [],
-                "noValue": "--",
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "light-green",
-                      "value": null
-                    }
-                  ]
-                },
-                "unit": "none"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Used (%)"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.displayMode",
-                      "value": "lcd-gauge"
-                    },
-                    {
-                      "id": "thresholds",
-                      "value": {
-                        "mode": "absolute",
-                        "steps": [
-                          {
-                            "color": "light-green",
-                            "value": null
-                          },
-                          {
-                            "color": "semi-dark-yellow",
-                            "value": 70
-                          },
-                          {
-                            "color": "dark-red",
-                            "value": 80
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "id": "decimals",
-                      "value": 1
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Status"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.displayMode",
-                      "value": "color-background"
-                    },
-                    {
-                      "id": "mappings",
-                      "value": [
-                        {
-                          "options": {
-                            "0": {
-                              "text": "Bound"
-                            },
-                            "1": {
-                              "text": "Pending"
-                            },
-                            "2": {
-                              "text": "Lost"
-                            }
-                          },
-                          "type": "value"
-                        }
-                      ]
-                    },
-                    {
-                      "id": "thresholds",
-                      "value": {
-                        "mode": "absolute",
-                        "steps": [
-                          {
-                            "color": "light-green",
-                            "value": null
-                          },
-                          {
-                            "color": "light-green",
-                            "value": 0
-                          },
-                          {
-                            "color": "semi-dark-orange",
-                            "value": 1
-                          },
-                          {
-                            "color": "semi-dark-red",
-                            "value": 2
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "id": "noValue",
-                      "value": "--"
-                    },
-                    {
-                      "id": "custom.align",
-                      "value": "center"
-                    },
-                    {
-                      "id": "custom.filterable",
-                      "value": true
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Namespace"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 120
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Status"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 80
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Capacity (GiB)"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 120
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Used (GiB)"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 120
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Available (GiB)"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 120
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "StorageClass"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 150
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "PersistentVolumeClaim"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 370
-                    },
-                    {
-                      "id": "links",
-                      "value": [
-                        {
-                          "title": "",
-                          "url": "/d/919b92a8e8041bd567af9edab12c840c/kubernetes-persistent-volumes?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-volume=${__data.fields[\"PersistentVolumeClaim\"]}"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 21
-            },
-            "id": 120,
-            "interval": "",
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "frameIndex": 2,
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "9.3.2",
-            "targets": [
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": " sum by (persistentvolumeclaim,namespace,storageclass,volumename) (kube_persistentvolumeclaim_info{namespace=~\"${namespace}\"})",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "B"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "C"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "D"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum(kube_persistentvolumeclaim_status_phase{namespace=~\"${namespace}\",phase=~\"(Pending|Lost)\"}) by (persistentvolumeclaim) + sum(kube_persistentvolumeclaim_status_phase{namespace=~\"${namespace}\",phase=~\"(Lost)\"}) by (persistentvolumeclaim)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "E"
-              },
-              {
-                "datasource": {
-                  "type": "prometheus",
-                  "uid": "P1809F7CD0C75ACF3"
-                },
-                "editorMode": "code",
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"} * 100)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "F"
-              }
-            ],
-            "title": "Persistent Volume Claim",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "persistentvolumeclaim"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "Time 1": true,
-                    "Time 2": true,
-                    "Time 3": true,
-                    "Time 4": true,
-                    "Time 5": true,
-                    "Time 6": true,
-                    "Value #A": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Time 1": "",
-                    "Time 2": "",
-                    "Time 3": "",
-                    "Time 4": "",
-                    "Time 5": "",
-                    "Time 6": "",
-                    "Value #A": "",
-                    "Value #B": "Capacity (GiB)",
-                    "Value #C": "Used (GiB)",
-                    "Value #D": "Available (GiB)",
-                    "Value #E": "Status",
-                    "Value #F": "Used (%)",
-                    "namespace": "Namespace",
-                    "persistentvolumeclaim": "PersistentVolumeClaim",
-                    "storageclass": "StorageClass",
-                    "volumename": "PhysicalVolume"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          }
-        ],
-        "title": "Persistent Volume Claims",
-        "type": "row"
-      }
-    ],
-    "refresh": "5s",
-    "schemaVersion": 37,
-    "style": "dark",
-    "tags": [
-      "kubernetes"
-    ],
-    "templating": {
-      "list": [
+      "pluginVersion": "9.3.2",
+      "targets": [
         {
-          "current": {
-            "selected": false,
-            "text": "prometheus",
-            "value": "prometheus"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "datasource",
-          "options": [],
-          "query": "prometheus",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "type": "datasource"
-        },
-        {
-          "allValue": ".*",
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
-            ]
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "definition": "label_values(probe_success, instance)",
-          "hide": 2,
-          "includeAll": true,
-          "label": "services",
-          "multi": true,
-          "name": "services",
-          "options": [],
-          "query": {
-            "query": "label_values(probe_success, instance)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "isNone": true,
-            "selected": false,
-            "text": "None",
-            "value": ""
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
-          "hide": 2,
-          "includeAll": false,
-          "multi": false,
-          "name": "cluster",
-          "options": [],
-          "query": {
-            "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": false,
-            "text": "infra",
-            "value": "infra"
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "definition": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "role",
-          "options": [],
-          "query": {
-            "query": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
-            ]
-          },
           "datasource": {
             "type": "prometheus",
             "uid": "P1809F7CD0C75ACF3"
           },
-          "definition": "label_values(kube_node_role{cluster=\"$cluster\", role=\"$role\"}, node)",
-          "hide": 0,
-          "includeAll": true,
-          "multi": true,
-          "name": "node",
-          "options": [],
-          "query": {
-            "query": "label_values(kube_node_role{cluster=\"$cluster\", role=\"$role\"}, node)",
-            "refId": "StandardVariableQuery"
+          "editorMode": "code",
+          "expr": "count(kube_node_info{cluster=\"$cluster\", node=~\"$node\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Nodes",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
             ]
           },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 1
+      },
+      "id": 90,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "P1809F7CD0C75ACF3"
           },
-          "definition": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
-          "hide": 0,
-          "includeAll": true,
-          "multi": true,
-          "name": "namespace",
-          "options": [],
-          "query": {
-            "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
-            "refId": "StandardVariableQuery"
+          "editorMode": "code",
+          "expr": "count(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}==0)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Healthy Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 5,
+        "y": 1
+      },
+      "id": 94,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_namespace_created)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Namespace",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgb(31, 120, 193)",
+            "mode": "fixed"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 8,
+        "y": 1
+      },
+      "id": 98,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": " count(count by (pod)(container_spec_memory_reservation_limit_bytes{pod!=\"\", node=~\"$node\", namespace=~\"$namespace\"}))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total pods",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "#37872D",
+                "value": 0
+              },
+              {
+                "color": "#d44a3a",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 10,
+        "y": 1
+      },
+      "id": 104,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_pod_container_status_terminated_reason{reason!=\"Completed\", namespace=~\"$namespace\"} !=0 ) or vector(0)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Terminated pods",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "#37872D",
+                "value": 0
+              },
+              {
+                "color": "#d44a3a",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 13,
+        "y": 1
+      },
+      "id": 102,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_pod_container_status_waiting{namespace=~\"$namespace\"} !=0 ) or vector(0)",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting pods",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 16,
+        "y": 1
+      },
+      "id": 129,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "count(x509_cert_not_after)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Certificates",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 19,
+        "y": 1
+      },
+      "id": 127,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(((x509_cert_not_after - time()) / 86400) < bool 0)",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Expired Certificates",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 126,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(0 < ((x509_cert_not_after - time()) / 86400) < bool 7)",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Certificates expiring within 7 days",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 3
+      },
+      "id": 91,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}!=0) OR on() vector(0)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unhealthy Nodes",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fill": 10,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 108,
+      "interval": "1m",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 0,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.3.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\", namespace=~\"$namespace\"}) by (namespace)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": false,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "min": 0,
+          "show": true
         },
         {
-          "current": {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fill": 10,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 110,
+      "interval": "1m",
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 0,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.3.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\",node=~\"$node\", namespace=~\"$namespace\"}) by (namespace)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Memory Usage (w/o cache)",
+      "tooltip": {
+        "shared": false,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 113,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "left",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "-",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #memory_used"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #memory_requests"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value #memory_limits"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Node"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 250
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "",
+                        "url": "/d/JzmufwUVz/node-exporter-nodes?var-datasource=$datasource&var-instance=${__data.fields.node}"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 115
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "",
+                        "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Pod"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 226
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "",
+                        "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod\"]}"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Node Status"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "0": {
+                            "color": "green",
+                            "index": 1,
+                            "text": "Up"
+                          },
+                          "1": {
+                            "color": "red",
+                            "index": 0,
+                            "text": "Down"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-text"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 13
+          },
+          "id": 118,
+          "links": [],
+          "options": {
+            "footer": {
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "max(kube_pod_container_resource_requests{resource=\"memory\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 1,
+              "refId": "memory_requests"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "max(kube_pod_container_resource_limits{resource=\"memory\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+              "format": "table",
+              "instant": true,
+              "intervalFactor": 1,
+              "refId": "memory_limits"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "max(container_memory_working_set_bytes{name!=\"\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "memory_used"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "max(kube_pod_container_resource_requests{resource=\"cpu\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 1,
+              "refId": "cpu_requests"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "max(kube_pod_container_resource_limits{resource=\"cpu\"}) by (pod)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 1,
+              "refId": "cpu_limits"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\", container_name!=\"POD\"}[5m])) by (pod)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "cpu_used"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "max(kube_pod_info) by (pod,namespace,node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "pod_info"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}!=0) by (node) or sum(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}==0) by (node)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "",
+              "range": false,
+              "refId": "node_status"
+            }
+          ],
+          "title": "Memory usage per container",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {
+                "reducers": []
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Value #A": true,
+                  "Value #pod_info": true,
+                  "namespace": false,
+                  "pod": false
+                },
+                "indexByName": {
+                  "Time": 10,
+                  "Value #cpu_limits": 9,
+                  "Value #cpu_requests": 8,
+                  "Value #cpu_used": 7,
+                  "Value #memory_limits": 6,
+                  "Value #memory_requests": 5,
+                  "Value #memory_used": 4,
+                  "Value #node_status": 3,
+                  "Value #pod_info": 11,
+                  "namespace": 1,
+                  "node": 2,
+                  "pod": 0
+                },
+                "renameByName": {
+                  "Value #cpu_limits": "CPU Limits",
+                  "Value #cpu_requests": "CPU Requests",
+                  "Value #cpu_used": "CPU Used",
+                  "Value #memory_limits": "RAM Limits ",
+                  "Value #memory_requests": "RAM Requests",
+                  "Value #memory_used": "RAM Used",
+                  "Value #node_status": "Node Status",
+                  "namespace": "Namespace",
+                  "node": "Node",
+                  "pod": "Pod"
+                }
+              }
+            },
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "config": {
+                      "id": "isNotNull",
+                      "options": {}
+                    },
+                    "fieldName": "Node Status"
+                  }
+                ],
+                "match": "any",
+                "type": "include"
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Node Overview",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 31,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Running"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 0,
+            "y": 62
+          },
+          "id": 24,
+          "links": [],
+          "maxDataPoints": 3,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_number_unavailable{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_number_available{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Running",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Daemon Sets",
+          "transformations": [],
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Running"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 4,
+            "y": 62
+          },
+          "id": 25,
+          "links": [],
+          "maxDataPoints": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "count(kube_deployment_created{namespace=~\"$namespace\"}) - count(kube_deployment_status_replicas_available{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "count(kube_deployment_created{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Running",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Deployments",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 8,
+            "y": 62
+          },
+          "id": 26,
+          "links": [],
+          "maxDataPoints": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_job_status_succeeded{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Succeeded",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_job_status_failed{namespace=~\"$namespace\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Jobs",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Running"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 12,
+            "y": 62
+          },
+          "id": 57,
+          "links": [],
+          "maxDataPoints": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_status_phase{phase!=\"Running\", namespace=~\"$namespace\"} and kube_pod_status_phase{phase!=\"Succeeded\", namespace=~\"$namespace\"}) OR on() vector(0)",
+              "interval": "",
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_status_phase{phase=\"Running\", namespace=~\"$namespace\"} or kube_pod_status_phase{phase=\"Succeeded\", namespace=~\"$namespace\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Running",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Pods",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Running"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 16,
+            "y": 62
+          },
+          "id": 27,
+          "links": [],
+          "maxDataPoints": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "count(kube_replicaset_created{namespace=~\"$namespace\"}) - count(kube_replicaset_status_ready_replicas{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "count(kube_replicaset_created{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Running",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Replica Sets",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Running"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 20,
+            "y": 62
+          },
+          "id": 29,
+          "links": [],
+          "maxDataPoints": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "count(kube_statefulset_created{namespace=~\"$namespace\"}) - count(kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "count(kube_statefulset_created{namespace=~\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "Running",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Stateful Sets",
+          "type": "piechart"
+        }
+      ],
+      "title": "Workload Status",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 59,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#629e51",
+                "mode": "fixed"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 177
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 63
+          },
+          "id": 111,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "footer": {
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_number_available{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+              "format": "table",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Available",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_desired_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Desired",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_current_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Current",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_number_ready{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Ready",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_updated_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Up-To-Date",
+              "range": true,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_daemonset_status_number_unavailable{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Unavailable",
+              "range": true,
+              "refId": "F"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value #A": 4,
+                  "Value #B": 5,
+                  "Value #C": 6,
+                  "container": 3,
+                  "daemonset": 2,
+                  "namespace": 1
+                },
+                "renameByName": {
+                  "Value #A": "Available",
+                  "Value #B": "Desired",
+                  "Value #C": "Current",
+                  "Value #D": "Ready",
+                  "Value #E": "Up-To-Date",
+                  "Value #F": "Unavailable",
+                  "container": "Container",
+                  "daemonset": "Deamonset",
+                  "namespace": "Namespace"
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "Available": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Container": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Current": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Daemonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Deamonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Desired": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod Name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pods": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Ready": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Unavailable": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Up-To-Date": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #A": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #B": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #C": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "container": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "daemonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Daemon Sets",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 63,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#629e51",
+                "mode": "fixed"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 177
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 64
+          },
+          "id": 64,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "footer": {
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) by (namespace,deployment)",
+              "format": "table",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Available",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_deployment_status_replicas_ready{namespace=~\"$namespace\"}) by (namespace,deployment)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "{{label_name}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_deployment_status_replicas_updated{namespace=~\"$namespace\"}) by (namespace,deployment)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Up-To-Date",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_deployment_status_replicas_unavailable) by (namespace,deployment)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Unavailable",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value": 4,
+                  "container": 3,
+                  "deployment": 2,
+                  "namespace": 1
+                },
+                "renameByName": {
+                  "Value": "Available",
+                  "Value #A": "Available",
+                  "Value #B": "Ready",
+                  "Value #C": "Up-To-Date",
+                  "Value #D": "Unavailable",
+                  "container": "Container",
+                  "deployment": "Deployment",
+                  "namespace": "Namespace"
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "Available": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Container": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Current": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Daemonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Deamonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Deployment": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Desired": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod Name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pods": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Ready": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Time": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Unavailable": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Up-To-Date": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #A": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #B": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #C": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "container": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "daemonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "deployment": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Deployments",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 37,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#629e51",
+                "mode": "fixed"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 177
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 197
+          },
+          "id": 65,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "footer": {
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_job_status_active{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Active",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_job_status_succeeded{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Succeeded",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_job_status_failed{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value": 4,
+                  "job": 2,
+                  "job_name": 3,
+                  "namespace": 1
+                },
+                "renameByName": {
+                  "Value": "Active",
+                  "Value #A": "Active",
+                  "Value #B": "Succeeded",
+                  "Value #C": "Failed",
+                  "container": "",
+                  "job": "Job",
+                  "job_name": "Job Name",
+                  "namespace": "Namespace"
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "Active": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Available": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Container": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Current": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Daemonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Deamonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Deployment": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Desired": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Failed": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Job": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Job Name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod Name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pods": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Ready": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Succeeded": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Time": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Unavailable": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Up-To-Date": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #A": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #B": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #C": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "container": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "daemonset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "deployment": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "job": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "job_name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Jobs",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 33,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#629e51",
+                "mode": "fixed"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 256
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Pod"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod\"]}"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 427
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 131
+          },
+          "id": 30,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "footer": {
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_status_phase{phase=\"Running\", namespace=~\"$namespace\"}) by (namespace, pod)",
+              "format": "table",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Running",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_status_phase{phase=\"Failed\", namespace=~\"$namespace\"}) by (namespace, pod)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Failed",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_status_phase{phase=\"Pending\", namespace=~\"$namespace\"}) by (namespace, pod)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Pending",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_status_phase{phase=\"Succeeded\", namespace=~\"$namespace\"}) by (namespace, pod)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Succeeded",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_status_phase{phase=\"Unknown\", namespace=~\"$namespace\"}) by (namespace, pod)",
+              "format": "table",
+              "hide": false,
+              "legendFormat": "Unknown",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value #A": 3,
+                  "Value #B": 4,
+                  "namespace": 1,
+                  "pod": 2
+                },
+                "renameByName": {
+                  "Time": "",
+                  "Value": "",
+                  "Value #A": "Running",
+                  "Value #B": "Failed",
+                  "Value #C": "Pending",
+                  "Value #D": "Succeeded",
+                  "Value #E": "Unknown",
+                  "namespace": "Namespace",
+                  "pod": "Pod"
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "Failed": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pending": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod Name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pods": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Running": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Succeeded": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Time": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Unknown": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #A": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #B": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Pods",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 67,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#629e51",
+                "mode": "fixed"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 256
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 199
+          },
+          "id": 68,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "footer": {
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_replicaset_status_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
+              "format": "table",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Current",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_replicaset_status_ready_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Ready",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_replicaset_spec_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Desired",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value #A": 3,
+                  "Value #B": 4,
+                  "Value #C": 5,
+                  "namespace": 1,
+                  "replicaset": 2
+                },
+                "renameByName": {
+                  "Time": "",
+                  "Value": "",
+                  "Value #A": "Current",
+                  "Value #B": "Ready",
+                  "Value #C": "Desired",
+                  "Value #D": "Succeeded",
+                  "Value #E": "Unknown",
+                  "namespace": "Namespace",
+                  "pod": "Pod",
+                  "replicaset": "Replica Sets"
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "Current": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Desired": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Failed": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pending": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod Name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pods": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Ready": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Replica Sets": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Running": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Succeeded": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Time": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Unknown": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #A": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #B": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "replicaset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Replica Sets",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 70,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#629e51",
+                "mode": "fixed"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 256
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Pod"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Drill down",
+                        "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod Name\"]}"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 427
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 84
+          },
+          "id": 71,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "footer": {
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_statefulset_status_replicas_current{namespace=~\"$namespace\"}) by (namespace, statefulset)",
+              "format": "table",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Current",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) by (namespace, statefulset)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Ready",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_statefulset_replicas{namespace=~\"$namespace\"}) by (namespace, statefulset)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Desired",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_statefulset_status_replicas_available) by (namespace, statefulset)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Available",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_statefulset_status_replicas_updated) by (namespace, statefulset)",
+              "format": "table",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Updated",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value #A": 3,
+                  "Value #B": 4,
+                  "Value #C": 5,
+                  "Value #D": 6,
+                  "Value #E": 7,
+                  "namespace": 1,
+                  "statefulset": 2
+                },
+                "renameByName": {
+                  "Time": "",
+                  "Value": "",
+                  "Value #A": "Current",
+                  "Value #B": "Ready",
+                  "Value #C": "Desired",
+                  "Value #D": "Available",
+                  "Value #E": "Updated",
+                  "namespace": "Namespace",
+                  "pod": "Pod",
+                  "replicaset": "Replica Sets",
+                  "statefulset": "StatefulSet"
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "Available": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Current": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Desired": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Failed": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pending": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pod Name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Pods": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Ready": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Replica Sets": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Running": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "StatefulSet": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Succeeded": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Time": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Unknown": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Updated": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #A": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "Value #B": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "namespace": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "pod": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "replicaset": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Stateful Sets",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 115,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "--",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-green"
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Used (%)"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "lcd-gauge"
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "light-green"
+                        },
+                        {
+                          "color": "semi-dark-yellow",
+                          "value": 70
+                        },
+                        {
+                          "color": "dark-red",
+                          "value": 80
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 1
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Status"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background"
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "0": {
+                            "text": "Bound"
+                          },
+                          "1": {
+                            "text": "Pending"
+                          },
+                          "2": {
+                            "text": "Lost"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "light-green"
+                        },
+                        {
+                          "color": "light-green",
+                          "value": 0
+                        },
+                        {
+                          "color": "semi-dark-orange",
+                          "value": 1
+                        },
+                        {
+                          "color": "semi-dark-red",
+                          "value": 2
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "--"
+                  },
+                  {
+                    "id": "custom.align",
+                    "value": "center"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 120
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Status"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 80
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Capacity (GiB)"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 120
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Used (GiB)"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 120
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Available (GiB)"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 120
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "StorageClass"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "PersistentVolumeClaim"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 370
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "",
+                        "url": "/d/919b92a8e8041bd567af9edab12c840c/kubernetes-persistent-volumes?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-volume=${__data.fields[\"PersistentVolumeClaim\"]}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 53
+          },
+          "id": 120,
+          "interval": "",
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "frameIndex": 2,
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": false,
+                "displayName": "PersistentVolumeClaim"
+              }
+            ]
+          },
+          "pluginVersion": "9.3.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": " sum by (persistentvolumeclaim,namespace,storageclass,volumename) (kube_persistentvolumeclaim_info{namespace=~\"${namespace}\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_persistentvolumeclaim_status_phase{namespace=~\"${namespace}\",phase=~\"(Pending|Lost)\"}) by (persistentvolumeclaim) + sum(kube_persistentvolumeclaim_status_phase{namespace=~\"${namespace}\",phase=~\"(Lost)\"}) by (persistentvolumeclaim)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+              },
+              "editorMode": "code",
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"} * 100)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "F"
+            }
+          ],
+          "title": "Persistent Volume Claim",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "persistentvolumeclaim"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 2": true,
+                  "Time 3": true,
+                  "Time 4": true,
+                  "Time 5": true,
+                  "Time 6": true,
+                  "Value #A": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Time 1": "",
+                  "Time 2": "",
+                  "Time 3": "",
+                  "Time 4": "",
+                  "Time 5": "",
+                  "Time 6": "",
+                  "Value #A": "",
+                  "Value #B": "Capacity (GiB)",
+                  "Value #C": "Used (GiB)",
+                  "Value #D": "Available (GiB)",
+                  "Value #E": "Status",
+                  "Value #F": "Used (%)",
+                  "namespace": "Namespace",
+                  "persistentvolumeclaim": "PersistentVolumeClaim",
+                  "storageclass": "StorageClass",
+                  "volumename": "PhysicalVolume"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Persistent Volume Claims",
+      "type": "row"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [
+    "kubernetes"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(probe_success, instance)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "services",
+        "multi": true,
+        "name": "services",
+        "options": [],
+        "query": {
+          "query": "label_values(probe_success, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "infra",
+          "value": "infra"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "node_role",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "label_values(kube_node_role{cluster=\"$cluster\", role=\"$node_role\"}, node)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_node_role{cluster=\"$cluster\", role=\"$node_role\"}, node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "80",
+          "value": "80"
+        },
+        "hide": 2,
+        "label": "PVC % Used Warning Threshold",
+        "name": "warning_threshold",
+        "options": [
+          {
             "selected": true,
             "text": "80",
             "value": "80"
-          },
-          "hide": 2,
-          "label": "PVC % Used Warning Threshold",
-          "name": "warning_threshold",
-          "options": [
-            {
-              "selected": true,
-              "text": "80",
-              "value": "80"
-            }
-          ],
-          "query": "80",
-          "skipUrlSync": false,
-          "type": "textbox"
-        }
-      ]
-    },
-    "time": {
-      "from": "now-5m",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ]
-    },
-    "timezone": "",
-    "title": "Kubernetes - Fury Cluster Overview",
-    "uid": "yEDFYXLVz",
-    "version": 1
-  }
+          }
+        ],
+        "query": "80",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Kubernetes - Fury Cluster Overview",
+  "uid": "yEDFYXLVz",
+  "version": 2,
+  "weekStart": ""
+}

--- a/katalog/grafana/dashboards/fury-cluster-overview.json
+++ b/katalog/grafana/dashboards/fury-cluster-overview.json
@@ -1,0 +1,4367 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "$$hashKey": "object:173",
+          "builtIn": 1,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": 12202,
+    "graphTooltip": 0,
+    "links": [
+      {
+        "asDropdown": true,
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": false,
+        "tags": [
+          "kubernetes-mixin"
+        ],
+        "targetBlank": false,
+        "title": "Dashboards",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
+      }
+    ],
+    "liveNow": false,
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 82,
+        "panels": [],
+        "title": "Cluster Status",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 0,
+          "y": 1
+        },
+        "id": 93,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "count(kube_node_info{cluster=\"$cluster\", node=~\"$node\"})",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Total Nodes",
+        "transformations": [],
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 4,
+          "y": 1
+        },
+        "id": 90,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "count(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}==0)",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Healthy Nodes",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 10,
+          "y": 1
+        },
+        "id": 94,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "count(kube_namespace_created)",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Total Namespace",
+        "transformations": [],
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "rgb(31, 120, 193)",
+              "mode": "fixed"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 2,
+          "x": 14,
+          "y": 1
+        },
+        "id": 98,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+          "colorMode": "none",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": " count(count by (pod)(container_spec_memory_reservation_limit_bytes{pod!=\"\", node=~\"$node\", namespace=~\"$namespace\"}))",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Total pods",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#299c46",
+                  "value": null
+                },
+                {
+                  "color": "#37872D",
+                  "value": 0
+                },
+                {
+                  "color": "#d44a3a"
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 2,
+          "x": 16,
+          "y": 1
+        },
+        "id": 100,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+          "colorMode": "none",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "count(kube_persistentvolumeclaim_info{namespace=~\"$namespace\"}) ",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "title": "PVCs",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#299c46",
+                  "value": null
+                },
+                {
+                  "color": "#37872D",
+                  "value": 0
+                },
+                {
+                  "color": "#d44a3a",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 3,
+          "x": 18,
+          "y": 1
+        },
+        "id": 104,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "count(kube_pod_container_status_terminated_reason{reason!=\"Completed\", namespace=~\"$namespace\"} !=0 ) or vector(0)",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Terminated pods",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#299c46",
+                  "value": null
+                },
+                {
+                  "color": "#37872D",
+                  "value": 0
+                },
+                {
+                  "color": "#d44a3a",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 3,
+          "x": 21,
+          "y": 1
+        },
+        "id": 102,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "count(kube_pod_container_status_waiting{namespace=~\"$namespace\"} !=0 ) or vector(0)",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Waiting pods",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "dark-red",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 4,
+          "y": 3
+        },
+        "id": 91,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.3.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "editorMode": "code",
+            "expr": "count(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}!=0) OR on() vector(0)",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Unhealthy Nodes",
+        "type": "stat"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "fill": 10,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 108,
+        "interval": "1m",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 0,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.3.2",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "$datasource"
+            },
+            "editorMode": "code",
+            "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\", namespace=~\"$namespace\"}) by (namespace)",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "{{namespace}}",
+            "range": true,
+            "refId": "A",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "CPU Usage",
+        "tooltip": {
+          "shared": false,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "min": 0,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "fill": 10,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 110,
+        "interval": "1m",
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 0,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.3.2",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "$datasource"
+            },
+            "editorMode": "code",
+            "expr": "sum(container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\",node=~\"$node\", namespace=~\"$namespace\"}) by (namespace)",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "legendFormat": "{{namespace}}",
+            "range": true,
+            "refId": "A",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Memory Usage (w/o cache)",
+        "tooltip": {
+          "shared": false,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "bytes",
+            "logBase": 1,
+            "min": 0,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 12
+        },
+        "id": 113,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "align": "left",
+                  "displayMode": "auto",
+                  "filterable": true,
+                  "inspect": false
+                },
+                "mappings": [],
+                "noValue": "-",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Value #memory_used"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "bytes"
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 2
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Value #memory_requests"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "bytes"
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 2
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Value #memory_limits"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "bytes"
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 2
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Node"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 250
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "",
+                          "url": "/d/JzmufwUVz/node-exporter-nodes?var-datasource=$datasource&var-instance=${__data.fields.node}"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 115
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "",
+                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Pod"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 226
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "",
+                          "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod\"]}"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Node Status"
+                  },
+                  "properties": [
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "options": {
+                            "0": {
+                              "color": "green",
+                              "index": 1,
+                              "text": "Up"
+                            },
+                            "1": {
+                              "color": "red",
+                              "index": 0,
+                              "text": "Down"
+                            }
+                          },
+                          "type": "value"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "custom.displayMode",
+                      "value": "color-text"
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 11,
+              "w": 24,
+              "x": 0,
+              "y": 13
+            },
+            "id": 118,
+            "links": [],
+            "options": {
+              "footer": {
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "max(kube_pod_container_resource_requests{resource=\"memory\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "intervalFactor": 1,
+                "refId": "memory_requests"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "max(kube_pod_container_resource_limits{resource=\"memory\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 1,
+                "refId": "memory_limits"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "max(container_memory_working_set_bytes{name!=\"\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "intervalFactor": 1,
+                "legendFormat": "",
+                "refId": "memory_used"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "max(kube_pod_container_resource_requests{resource=\"cpu\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "intervalFactor": 1,
+                "refId": "cpu_requests"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "max(kube_pod_container_resource_limits{resource=\"cpu\"}) by (pod)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "intervalFactor": 1,
+                "refId": "cpu_limits"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\", container_name!=\"POD\"}[5m])) by (pod)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "intervalFactor": 1,
+                "legendFormat": "",
+                "refId": "cpu_used"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max(kube_pod_info) by (pod,namespace,node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "__auto",
+                "range": false,
+                "refId": "pod_info"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}!=0) by (node) or sum(kube_node_spec_unschedulable{cluster=\"$cluster\", node=~\"$node\"}==0) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "",
+                "range": false,
+                "refId": "node_status"
+              }
+            ],
+            "title": "Memory usage per container",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {
+                  "reducers": []
+                }
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true,
+                    "Value #A": true,
+                    "Value #pod_info": true,
+                    "namespace": false,
+                    "pod": false
+                  },
+                  "indexByName": {
+                    "Time": 10,
+                    "Value #cpu_limits": 9,
+                    "Value #cpu_requests": 8,
+                    "Value #cpu_used": 7,
+                    "Value #memory_limits": 6,
+                    "Value #memory_requests": 5,
+                    "Value #memory_used": 4,
+                    "Value #node_status": 3,
+                    "Value #pod_info": 11,
+                    "namespace": 1,
+                    "node": 2,
+                    "pod": 0
+                  },
+                  "renameByName": {
+                    "Value #cpu_limits": "CPU Limits",
+                    "Value #cpu_requests": "CPU Requests",
+                    "Value #cpu_used": "CPU Used",
+                    "Value #memory_limits": "RAM Limits ",
+                    "Value #memory_requests": "RAM Requests",
+                    "Value #memory_used": "RAM Used",
+                    "Value #node_status": "Node Status",
+                    "namespace": "Namespace",
+                    "node": "Node",
+                    "pod": "Pod"
+                  }
+                }
+              },
+              {
+                "id": "filterByValue",
+                "options": {
+                  "filters": [
+                    {
+                      "config": {
+                        "id": "isNotNull",
+                        "options": {}
+                      },
+                      "fieldName": "Node Status"
+                    }
+                  ],
+                  "match": "any",
+                  "type": "include"
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Node Status",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 31,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "decimals": 0,
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Failed"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Running"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 4,
+              "x": 0,
+              "y": 30
+            },
+            "id": 24,
+            "links": [],
+            "maxDataPoints": 3,
+            "options": {
+              "displayLabels": [],
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent"
+                ]
+              },
+              "pieType": "donut",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_number_unavailable{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_number_available{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Running",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Daemon Sets",
+            "transformations": [],
+            "type": "piechart"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "decimals": 0,
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Running"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Failed"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 4,
+              "x": 4,
+              "y": 30
+            },
+            "id": 25,
+            "links": [],
+            "maxDataPoints": 3,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent"
+                ]
+              },
+              "pieType": "donut",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "count(kube_deployment_created{namespace=~\"$namespace\"}) - count(kube_deployment_status_replicas_available{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "count(kube_deployment_created{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Running",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Deployments",
+            "type": "piechart"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "decimals": 0,
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Failed"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 4,
+              "x": 8,
+              "y": 30
+            },
+            "id": 26,
+            "links": [],
+            "maxDataPoints": 3,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent"
+                ]
+              },
+              "pieType": "donut",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_job_status_succeeded{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Succeeded",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_job_status_failed{namespace=~\"$namespace\"})",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Jobs",
+            "type": "piechart"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "decimals": 0,
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Running"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Failed"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 4,
+              "x": 12,
+              "y": 30
+            },
+            "id": 57,
+            "links": [],
+            "maxDataPoints": 3,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent"
+                ]
+              },
+              "pieType": "donut",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_status_phase{phase!=\"Running\", namespace=~\"$namespace\"} and kube_pod_status_phase{phase!=\"Succeeded\", namespace=~\"$namespace\"}) OR on() vector(0)",
+                "interval": "",
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_status_phase{phase=\"Running\", namespace=~\"$namespace\"} or kube_pod_status_phase{phase=\"Succeeded\", namespace=~\"$namespace\"})",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Running",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Pods",
+            "type": "piechart"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "decimals": 0,
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Running"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Failed"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 4,
+              "x": 16,
+              "y": 30
+            },
+            "id": 27,
+            "links": [],
+            "maxDataPoints": 3,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent"
+                ]
+              },
+              "pieType": "donut",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "count(kube_replicaset_created{namespace=~\"$namespace\"}) - count(kube_replicaset_status_ready_replicas{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "count(kube_replicaset_created{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Running",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Replica Sets",
+            "type": "piechart"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  }
+                },
+                "decimals": 0,
+                "mappings": [],
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Running"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Failed"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 4,
+              "x": 20,
+              "y": 30
+            },
+            "id": 29,
+            "links": [],
+            "maxDataPoints": 3,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "right",
+                "showLegend": true,
+                "values": [
+                  "percent"
+                ]
+              },
+              "pieType": "donut",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "count(kube_statefulset_created{namespace=~\"$namespace\"}) - count(kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "count(kube_statefulset_created{namespace=~\"$namespace\"})",
+                "interval": "",
+                "legendFormat": "Running",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Stateful Sets",
+            "type": "piechart"
+          }
+        ],
+        "title": "Workload Status",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 14
+        },
+        "id": 59,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "fixedColor": "#629e51",
+                  "mode": "fixed"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto",
+                  "filterable": true,
+                  "inspect": false
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 177
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "id": 111,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+              "footer": {
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_number_available{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+                "format": "table",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Available",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_desired_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Desired",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_current_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Current",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_number_ready{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Ready",
+                "range": true,
+                "refId": "D"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_updated_number_scheduled{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Up-To-Date",
+                "range": true,
+                "refId": "E"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_daemonset_status_number_unavailable{namespace=~\"$namespace\"}) by (namespace,daemonset)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Unavailable",
+                "range": true,
+                "refId": "F"
+              }
+            ],
+            "title": "Deamon Sets Status",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {}
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true
+                  },
+                  "indexByName": {
+                    "Time": 0,
+                    "Value #A": 4,
+                    "Value #B": 5,
+                    "Value #C": 6,
+                    "container": 3,
+                    "daemonset": 2,
+                    "namespace": 1
+                  },
+                  "renameByName": {
+                    "Value #A": "Available",
+                    "Value #B": "Desired",
+                    "Value #C": "Current",
+                    "Value #D": "Ready",
+                    "Value #E": "Up-To-Date",
+                    "Value #F": "Unavailable",
+                    "container": "Container",
+                    "daemonset": "Deamonset",
+                    "namespace": "Namespace"
+                  }
+                }
+              },
+              {
+                "id": "groupBy",
+                "options": {
+                  "fields": {
+                    "Available": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Container": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Current": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Daemonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Deamonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Desired": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod Name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pods": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Ready": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Unavailable": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Up-To-Date": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #A": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #B": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #C": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "container": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "daemonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    }
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Daemon Sets",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 15
+        },
+        "id": 63,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "fixedColor": "#629e51",
+                  "mode": "fixed"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto",
+                  "filterable": true,
+                  "inspect": false
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 177
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 16
+            },
+            "id": 64,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+              "footer": {
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) by (namespace,deployment)",
+                "format": "table",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Available",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_deployment_status_replicas_ready{namespace=~\"$namespace\"}) by (namespace,deployment)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "{{label_name}}",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_deployment_status_replicas_updated{namespace=~\"$namespace\"}) by (namespace,deployment)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Up-To-Date",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_deployment_status_replicas_unavailable) by (namespace,deployment)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Unavailable",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "Deployments Status",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {}
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true
+                  },
+                  "indexByName": {
+                    "Time": 0,
+                    "Value": 4,
+                    "container": 3,
+                    "deployment": 2,
+                    "namespace": 1
+                  },
+                  "renameByName": {
+                    "Value": "Available",
+                    "Value #A": "Available",
+                    "Value #B": "Ready",
+                    "Value #C": "Up-To-Date",
+                    "Value #D": "Unavailable",
+                    "container": "Container",
+                    "deployment": "Deployment",
+                    "namespace": "Namespace"
+                  }
+                }
+              },
+              {
+                "id": "groupBy",
+                "options": {
+                  "fields": {
+                    "Available": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Container": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Current": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Daemonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Deamonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Deployment": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Desired": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod Name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pods": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Ready": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Time": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Unavailable": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Up-To-Date": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #A": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #B": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #C": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "container": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "daemonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "deployment": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    }
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Deployments",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 37,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "fixedColor": "#629e51",
+                  "mode": "fixed"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto",
+                  "filterable": true,
+                  "inspect": false
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 177
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 17
+            },
+            "id": 65,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+              "footer": {
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_job_status_active{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Active",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_job_status_succeeded{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Succeeded",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_job_status_failed{namespace=~\"$namespace\"}) by (namespace, job, job_name)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Jobs Status",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {}
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true
+                  },
+                  "indexByName": {
+                    "Time": 0,
+                    "Value": 4,
+                    "job": 2,
+                    "job_name": 3,
+                    "namespace": 1
+                  },
+                  "renameByName": {
+                    "Value": "Active",
+                    "Value #A": "Active",
+                    "Value #B": "Succeeded",
+                    "Value #C": "Failed",
+                    "container": "",
+                    "job": "Job",
+                    "job_name": "Job Name",
+                    "namespace": "Namespace"
+                  }
+                }
+              },
+              {
+                "id": "groupBy",
+                "options": {
+                  "fields": {
+                    "Active": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Available": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Container": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Current": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Daemonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Deamonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Deployment": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Desired": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Failed": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Job": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Job Name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod Name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pods": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Ready": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Succeeded": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Time": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Unavailable": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Up-To-Date": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #A": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #B": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #C": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "container": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "daemonset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "deployment": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "job": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "job_name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    }
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Jobs",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 17
+        },
+        "id": 33,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "fixedColor": "#629e51",
+                  "mode": "fixed"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto",
+                  "filterable": true,
+                  "inspect": false
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 256
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Pod"
+                  },
+                  "properties": [
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod\"]}"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "custom.width",
+                      "value": 427
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 10,
+              "w": 24,
+              "x": 0,
+              "y": 18
+            },
+            "id": 30,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+              "footer": {
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_status_phase{phase=\"Running\", namespace=~\"$namespace\"}) by (namespace, pod)",
+                "format": "table",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Running",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_status_phase{phase=\"Failed\", namespace=~\"$namespace\"}) by (namespace, pod)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Failed",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_status_phase{phase=\"Pending\", namespace=~\"$namespace\"}) by (namespace, pod)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Pending",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_status_phase{phase=\"Succeeded\", namespace=~\"$namespace\"}) by (namespace, pod)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Succeeded",
+                "range": true,
+                "refId": "D"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_pod_status_phase{phase=\"Unknown\", namespace=~\"$namespace\"}) by (namespace, pod)",
+                "format": "table",
+                "hide": false,
+                "legendFormat": "Unknown",
+                "range": true,
+                "refId": "E"
+              }
+            ],
+            "title": "Pods Status",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {}
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true
+                  },
+                  "indexByName": {
+                    "Time": 0,
+                    "Value #A": 3,
+                    "Value #B": 4,
+                    "namespace": 1,
+                    "pod": 2
+                  },
+                  "renameByName": {
+                    "Time": "",
+                    "Value": "",
+                    "Value #A": "Running",
+                    "Value #B": "Failed",
+                    "Value #C": "Pending",
+                    "Value #D": "Succeeded",
+                    "Value #E": "Unknown",
+                    "namespace": "Namespace",
+                    "pod": "Pod"
+                  }
+                }
+              },
+              {
+                "id": "groupBy",
+                "options": {
+                  "fields": {
+                    "Failed": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pending": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod Name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pods": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Running": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Succeeded": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Time": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Unknown": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #A": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #B": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    }
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Pods",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 18
+        },
+        "id": 67,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "fixedColor": "#629e51",
+                  "mode": "fixed"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto",
+                  "filterable": true,
+                  "inspect": false
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 256
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 10,
+              "w": 24,
+              "x": 0,
+              "y": 19
+            },
+            "id": 68,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+              "footer": {
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_replicaset_status_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
+                "format": "table",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Current",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_replicaset_status_ready_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Ready",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_replicaset_spec_replicas{namespace=~\"$namespace\"}) by (namespace, replicaset)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Desired",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Replica Sets Status",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {}
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true
+                  },
+                  "indexByName": {
+                    "Time": 0,
+                    "Value #A": 3,
+                    "Value #B": 4,
+                    "Value #C": 5,
+                    "namespace": 1,
+                    "replicaset": 2
+                  },
+                  "renameByName": {
+                    "Time": "",
+                    "Value": "",
+                    "Value #A": "Current",
+                    "Value #B": "Ready",
+                    "Value #C": "Desired",
+                    "Value #D": "Succeeded",
+                    "Value #E": "Unknown",
+                    "namespace": "Namespace",
+                    "pod": "Pod",
+                    "replicaset": "Replica Sets"
+                  }
+                }
+              },
+              {
+                "id": "groupBy",
+                "options": {
+                  "fields": {
+                    "Current": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Desired": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Failed": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pending": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod Name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pods": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Ready": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Replica Sets": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Running": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Succeeded": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Time": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Unknown": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #A": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #B": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "replicaset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    }
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Replica Sets",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 19
+        },
+        "id": 70,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "fixedColor": "#629e51",
+                  "mode": "fixed"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto",
+                  "filterable": true,
+                  "inspect": false
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "text": "N/A"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 256
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-namespace=${__data.fields.Namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Pod"
+                  },
+                  "properties": [
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "Drill down",
+                          "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-pod=${__data.fields[\"Pod Name\"]}"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "custom.width",
+                      "value": 427
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 10,
+              "w": 24,
+              "x": 0,
+              "y": 20
+            },
+            "id": 71,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+              "footer": {
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_statefulset_status_replicas_current{namespace=~\"$namespace\"}) by (namespace, statefulset)",
+                "format": "table",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Current",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) by (namespace, statefulset)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Ready",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_statefulset_replicas{namespace=~\"$namespace\"}) by (namespace, statefulset)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Desired",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_statefulset_status_replicas_available) by (namespace, statefulset)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Available",
+                "range": true,
+                "refId": "D"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_statefulset_status_replicas_updated) by (namespace, statefulset)",
+                "format": "table",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Updated",
+                "range": true,
+                "refId": "E"
+              }
+            ],
+            "title": "Stateful Sets Status",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {}
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true
+                  },
+                  "indexByName": {
+                    "Time": 0,
+                    "Value #A": 3,
+                    "Value #B": 4,
+                    "Value #C": 5,
+                    "Value #D": 6,
+                    "Value #E": 7,
+                    "namespace": 1,
+                    "statefulset": 2
+                  },
+                  "renameByName": {
+                    "Time": "",
+                    "Value": "",
+                    "Value #A": "Current",
+                    "Value #B": "Ready",
+                    "Value #C": "Desired",
+                    "Value #D": "Available",
+                    "Value #E": "Updated",
+                    "namespace": "Namespace",
+                    "pod": "Pod",
+                    "replicaset": "Replica Sets",
+                    "statefulset": "StatefulSet"
+                  }
+                }
+              },
+              {
+                "id": "groupBy",
+                "options": {
+                  "fields": {
+                    "Available": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Current": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Desired": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Failed": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pending": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pod Name": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Pods": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Ready": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Replica Sets": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Running": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "StatefulSet": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Succeeded": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Time": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Unknown": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Updated": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #A": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "Value #B": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "namespace": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "pod": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    },
+                    "replicaset": {
+                      "aggregations": [],
+                      "operation": "groupby"
+                    }
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Stateful Sets",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 115,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto",
+                  "filterable": false,
+                  "inspect": false
+                },
+                "mappings": [],
+                "noValue": "--",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-green",
+                      "value": null
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Used (%)"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.displayMode",
+                      "value": "lcd-gauge"
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "light-green",
+                            "value": null
+                          },
+                          {
+                            "color": "semi-dark-yellow",
+                            "value": 70
+                          },
+                          {
+                            "color": "dark-red",
+                            "value": 80
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 1
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Status"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.displayMode",
+                      "value": "color-background"
+                    },
+                    {
+                      "id": "mappings",
+                      "value": [
+                        {
+                          "options": {
+                            "0": {
+                              "text": "Bound"
+                            },
+                            "1": {
+                              "text": "Pending"
+                            },
+                            "2": {
+                              "text": "Lost"
+                            }
+                          },
+                          "type": "value"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "light-green",
+                            "value": null
+                          },
+                          {
+                            "color": "light-green",
+                            "value": 0
+                          },
+                          {
+                            "color": "semi-dark-orange",
+                            "value": 1
+                          },
+                          {
+                            "color": "semi-dark-red",
+                            "value": 2
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "noValue",
+                      "value": "--"
+                    },
+                    {
+                      "id": "custom.align",
+                      "value": "center"
+                    },
+                    {
+                      "id": "custom.filterable",
+                      "value": true
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 120
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Status"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 80
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Capacity (GiB)"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 120
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Used (GiB)"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 120
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Available (GiB)"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 120
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "StorageClass"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 150
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "PersistentVolumeClaim"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 370
+                    },
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "",
+                          "url": "/d/919b92a8e8041bd567af9edab12c840c/kubernetes-persistent-volumes?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}&var-volume=${__data.fields[\"PersistentVolumeClaim\"]}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 21
+            },
+            "id": 120,
+            "interval": "",
+            "options": {
+              "footer": {
+                "fields": "",
+                "reducer": [
+                  "sum"
+                ],
+                "show": false
+              },
+              "frameIndex": 2,
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "9.3.2",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": " sum by (persistentvolumeclaim,namespace,storageclass,volumename) (kube_persistentvolumeclaim_info{namespace=~\"${namespace}\"})",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "D"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(kube_persistentvolumeclaim_status_phase{namespace=~\"${namespace}\",phase=~\"(Pending|Lost)\"}) by (persistentvolumeclaim) + sum(kube_persistentvolumeclaim_status_phase{namespace=~\"${namespace}\",phase=~\"(Lost)\"}) by (persistentvolumeclaim)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "E"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"} * 100)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "F"
+              }
+            ],
+            "title": "Persistent Volume Claim",
+            "transformations": [
+              {
+                "id": "seriesToColumns",
+                "options": {
+                  "byField": "persistentvolumeclaim"
+                }
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true,
+                    "Time 1": true,
+                    "Time 2": true,
+                    "Time 3": true,
+                    "Time 4": true,
+                    "Time 5": true,
+                    "Time 6": true,
+                    "Value #A": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {
+                    "Time 1": "",
+                    "Time 2": "",
+                    "Time 3": "",
+                    "Time 4": "",
+                    "Time 5": "",
+                    "Time 6": "",
+                    "Value #A": "",
+                    "Value #B": "Capacity (GiB)",
+                    "Value #C": "Used (GiB)",
+                    "Value #D": "Available (GiB)",
+                    "Value #E": "Status",
+                    "Value #F": "Used (%)",
+                    "namespace": "Namespace",
+                    "persistentvolumeclaim": "PersistentVolumeClaim",
+                    "storageclass": "StorageClass",
+                    "volumename": "PhysicalVolume"
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "Persistent Volume Claims",
+        "type": "row"
+      }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [
+      "kubernetes"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "prometheus",
+            "value": "prometheus"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "definition": "label_values(probe_success, instance)",
+          "hide": 2,
+          "includeAll": true,
+          "label": "services",
+          "multi": true,
+          "name": "services",
+          "options": [],
+          "query": {
+            "query": "label_values(probe_success, instance)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "current": {
+            "isNone": true,
+            "selected": false,
+            "text": "None",
+            "value": ""
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "definition": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
+          "hide": 2,
+          "includeAll": false,
+          "multi": false,
+          "name": "cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "infra",
+            "value": "infra"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "definition": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "role",
+          "options": [],
+          "query": {
+            "query": "label_values(kube_node_role{cluster=\"$cluster\"}, role)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "definition": "label_values(kube_node_role{cluster=\"$cluster\", role=\"$role\"}, node)",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "node",
+          "options": [],
+          "query": {
+            "query": "label_values(kube_node_role{cluster=\"$cluster\", role=\"$role\"}, node)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "definition": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "namespace",
+          "options": [],
+          "query": {
+            "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": "80",
+            "value": "80"
+          },
+          "hide": 2,
+          "label": "PVC % Used Warning Threshold",
+          "name": "warning_threshold",
+          "options": [
+            {
+              "selected": true,
+              "text": "80",
+              "value": "80"
+            }
+          ],
+          "query": "80",
+          "skipUrlSync": false,
+          "type": "textbox"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "",
+    "title": "Kubernetes - Fury Cluster Overview",
+    "uid": "yEDFYXLVz",
+    "version": 1
+  }

--- a/katalog/grafana/dashboards/kustomization.yaml
+++ b/katalog/grafana/dashboards/kustomization.yaml
@@ -19,3 +19,6 @@ configMapGenerator:
   - name: grafana-dashboard
     files:
       - grafana-overview.json
+  - name: fury-dashboard
+    files:
+      - fury-cluster-overview.json


### PR DESCRIPTION
A new dashboard has been added on Grafana which allows you to have an overview of the status of the resources (deployment, daemonset, etc) present on the cluster.