### PR TITLE
fix(mimir): set max_global_series_per_user unlimited

### DIFF
--- a/katalog/mimir/MAINTENANCE.md
+++ b/katalog/mimir/MAINTENANCE.md
@@ -18,17 +18,25 @@ helm template mimir-distributed /tmp/mimir-distributed -n monitoring --values MA
 With the `mimir-distributed-built.yaml` file, check differences with the current `deploy.yml` file and change accordingly.
 
 Move the dashboards in place:
+
 ```bash
 cp /tmp/mimir-distributed/mixins/dashboards/*.json dashboards
 ```
 
 Move the prometheus rules in place:
+
 ```bash
 helm template mimir-distributed /tmp/mimir-distributed \
-  --set metaMonitoring.prometheusRule.enabled=true --set metaMonitoring.prometheusRule.mimirAlerts=true --set metaMonitoring.prometheusRule.mimirRules=true \
-  -s templates/metamonitoring/mixin-alerts.yaml -s templates/metamonitoring/prometheusrule.yaml -s templates/metamonitoring/recording-rules.yaml \
+  --set metaMonitoring.prometheusRule.enabled=true \
+  --set metaMonitoring.prometheusRule.mimirAlerts=true \
+  --set metaMonitoring.prometheusRule.mimirRules=true \
+  -s templates/metamonitoring/mixin-alerts.yaml \
+  -s templates/metamonitoring/prometheusrule.yaml \
+  -s templates/metamonitoring/recording-rules.yaml \
   -n monitoring --values MAINTENANCE.values.yaml > rules.yaml
 ```
+
+Note: the `config/mimir.yaml` file is not generated via the Helm chart.
 
 What was customized:
 
@@ -41,3 +49,4 @@ What was customized:
 - PrometheusRules have been moved on a dedicated file
 - Removed Pod Security Policy
 - Added `compactor_blocks_retention_period: 720h` on mimir config
+- Added `max_global_series_per_user: 0` to mimir config

--- a/katalog/mimir/config/mimir.yaml
+++ b/katalog/mimir/config/mimir.yaml
@@ -55,6 +55,7 @@ ingester_client:
     max_recv_msg_size: 104857600
     max_send_msg_size: 104857600
 limits:
+  max_global_series_per_user: 0 # set manually. We disable the limit on series a user can push because we have only Prometheus pushing with the fury user.
   max_cache_freshness: 10m
   max_query_parallelism: 240
   max_total_query_length: 12000h
@@ -63,7 +64,7 @@ memberlist:
   abort_if_cluster_join_fails: false
   compression_enabled: false
   join_members:
-  - dns+mimir-distributed-gossip-ring.monitoring.svc.cluster.local.:7946
+    - dns+mimir-distributed-gossip-ring.monitoring.svc.cluster.local.:7946
 querier:
   max_concurrent: 16
 query_scheduler:


### PR DESCRIPTION
Mimir limits by default to 150000 series per user.

We push all the time series from Prometheus into Mimir with the same "fury" user. A standard KFD installation has already 150000 or more time series.

Being that we have just one user pushing to Mimir, disable the limit. As a maximum, we will push Prometheus' time series to Mimir.

Related: 
- https://github.com/sighupio/fury-distribution/pull/205