### PR TITLE
feat(thanos): deprecate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Kubernetes Fury Monitoring provides the following packages:
 | [kube-state-metrics](katalog/kube-state-metrics)       | `2.9.2`  | Service that generates metrics from Kubernetes API objects                                                                |
 | [node-exporter](katalog/node-exporter)                 | `1.6.1`  | Prometheus exporter for hardware and OS metrics exposed by \*NIX kernels                                                  |
 | [prometheus-adapter](katalog/prometheus-adapter)       | `0.11.1` | Kubernetes resource metrics, custom metrics, and external metrics APIs implementation.                                    |
-| [thanos](katalog/thanos)                               | `0.34.0` | Thanos is a high-availability Prometheus setup that provides long term storage via an external object store               |
+| [thanos](katalog/thanos) (DEPRECATED)                  | `0.34.0` | Thanos is a high-availability Prometheus setup that provides long term storage via an external object store               |
 | [x509-exporter](katalog/x509-exporter)                 | `3.12.0` | Provides monitoring for certificates                                                                                      |
 | [mimir](katalog/mimir)                                 | `2.11.0` | Mimir is an open source, horizontally scalable, highly available, multi-tenant TSDB for long-term storage for Prometheus. |
 | [haproxy](katalog/haproxy)                             | `N.A.`   | Grafana dashboards and prometheus rules (alerts) for HAproxy.                                                             |

--- a/katalog/thanos/README.md
+++ b/katalog/thanos/README.md
@@ -2,6 +2,10 @@
 
 <!-- <KFD-DOCS> -->
 
+> [!CAUTION]
+> The Thanos package has been deprecated and will be removed in the next release.
+> Refer to the [Mimir package](../mimir/README.md) as a replacement for HA Prometheus deployments and long-term storage for metrics.
+
 Thanos is an opensource Prometheus setup that allows having 2 important features:
 
 1. high availability on Prometheus (setting more Prometheus replicas)


### PR DESCRIPTION
Deprecate Thanos as package in favour of Mimir for achieving HA Prometheus installations and long-term storage for metrics.

Closes https://github.com/sighupio/product-management/issues/513