### PR TITLE
fix(mimir): bump to v2.14.0

### DIFF
--- a/docs/releases/v3.3.0.md
+++ b/docs/releases/v3.3.0.md
@@ -2,7 +2,7 @@
 
 Welcome to the latest release of the `monitoring` core module of the [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution), maintained by team SIGHUP.
 
-This release updates components across all packages bringing the latest features and bugfixes from upstream, and deprecates the Thanos package.
+This release updates components across all packages bringing the latest features and bug fixes from upstream, and deprecates the Thanos package.
 
 ## Component Images 🚢
 
@@ -20,7 +20,7 @@ This release updates components across all packages bringing the latest features
 | `thanos`              | `v0.34.0` **DEPRECATED**: see below.                                                                       | No Update                    |
 | `x509-exporter`       | [`v3.17.0`](https://github.com/enix/x509-certificate-exporter/releases/tag/v3.17.0)                        | v3.12.0                      |
 | `karma`               | [`v0.113`](https://github.com/prymitive/karma/releases/tag/v0.113)                                         | No Update                    |
-| `mimir`               | [`v2.14.0`](https://github.com/grafana/mimir/releases/tag/mimir-2.14.0)                                    | v2.11.1                      |
+| `mimir`               | [`v2.14.0`](https://github.com/grafana/mimir/releases/tag/mimir-2.14.0)                                    | v2.11.0                      |
 | `minio-ha`            | [`RELEASE.2024-10-13T13-34-11Z`](https://github.com/minio/minio/releases/tag/RELEASE.2024-10-13T13-34-11Z) | RELEASE.2024-02-09T21-25-16Z |
 
 > Please refer the individual release notes to get a detailed info on the releases.

--- a/katalog/mimir/MAINTENANCE.values.yaml
+++ b/katalog/mimir/MAINTENANCE.values.yaml
@@ -2,6 +2,10 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# -- Overrides the version used to determine compatibility of resources with the target Kubernetes cluster.
+# This is useful when using `helm template`, because then helm will use the client version of kubectl as the Kubernetes version,
+# which may or may not match your cluster's server version. Example: 'v1.24.4'. Set to null to use the version that helm
+# devises.
 kubeVersionOverride: 1.29.0
 
 useExternalConfig: true
@@ -10,7 +14,7 @@ image:
   # -- Grafana Mimir container image repository. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.repository'
   repository: grafana/mimir
   # -- Grafana Mimir container image tag. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.tag'
-  tag: 2.10.3
+  tag: 2.14.0
   # -- Container pull policy - shared between Grafana Mimir and Grafana Enterprise Metrics
   pullPolicy: IfNotPresent
   # -- Optionally specify an array of imagePullSecrets - shared between Grafana Mimir and Grafana Enterprise Metrics
@@ -26,10 +30,10 @@ mimir:
       storage:
         backend: s3
         s3:
-          access_key_id: 'minio'
-          secret_access_key: 'minio123'
-          endpoint: 'minio-monitoring:9000'
-          insecure: true      
+          access_key_id: "minio"
+          secret_access_key: "minio123"
+          endpoint: "minio-monitoring:9000"
+          insecure: true
 
     blocks_storage:
       s3:
@@ -100,7 +104,6 @@ ingester:
   zoneAwareReplication:
     # -- Enable zone-aware replication for ingester
     enabled: false
- 
 
 overrides_exporter:
   enabled: false
@@ -181,8 +184,7 @@ store_gateway:
     # Subdirectory of Store-gateway data Persistent Volume to mount
     # Useful if the volume's root directory is not empty
     #
-    subPath: ''
-
+    subPath: ""
 
     # Store-gateway data Persistent Volume Storage Class
     # If defined, storageClassName: <storageClass>
@@ -233,7 +235,7 @@ compactor:
     # Subdirectory of compactor data Persistent Volume to mount
     # Useful if the volume's root directory is not empty
     #
-    subPath: ''
+    subPath: ""
 
     # compactor data Persistent Volume Storage Class
     # If defined, storageClassName: <storageClass>
@@ -248,7 +250,7 @@ memcached:
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
-    tag: 1.6.19-alpine
+    tag: 1.6.31-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
 
@@ -258,7 +260,7 @@ memcachedExporter:
 
   image:
     repository: prom/memcached-exporter
-    tag: v0.11.2
+    tag: v0.14.4
     pullPolicy: IfNotPresent
 
   resources:
@@ -333,7 +335,7 @@ gateway:
       # -- The nginx image repository
       repository: nginxinc/nginx-unprivileged
       # -- The nginx image tag
-      tag: 1.25-alpine
+      tag: 1.27-alpine
 
 metaMonitoring:
   # Dashboard configuration for deploying Grafana dashboards for Mimir
@@ -397,11 +399,11 @@ gr-metricname-cache:
 # that writing and reading metrics works. Currently not supported for
 # installations using GEM token-based authentication.
 smoke_test:
-  image:
-    repository: grafana/mimir-continuous-test
-    tag: 2.10.3
-    pullPolicy: IfNotPresent
-  tenantId: ''
+  # -- Controls the backoffLimit on the Kubernetes Job. The Job is marked as failed after that many retries.
+  backoffLimit: 5
+  # The image section has been removed as continuous test is now a module of the regular Mimir image.
+  # See settings for the image at the top image section.
+  tenantId: ""
   extraArgs: {}
   env: []
   extraEnvFrom: []
@@ -415,14 +417,6 @@ smoke_test:
 # https://grafana.com/docs/mimir/latest/manage/tools/mimir-continuous-test/
 continuous_test:
   enabled: true
-  # -- Number of replicas to start of continuous test
-  replicas: 1
-  image:
-    repository: grafana/mimir-continuous-test
-    tag: 2.10.3
-    pullPolicy: IfNotPresent
-    # Note: optional pullSecrets are set in toplevel 'image' section, not here
-
   # -- Authentication settings of continuous test
   auth:
     # -- Type of authentication to use (tenantId, basicAuth, bearerToken)
@@ -430,7 +424,7 @@ continuous_test:
     # -- The tenant to use for tenantId or basicAuth authentication type
     # In case of tenantId authentication, it is injected as the X-Scope-OrgID header on requests.
     # In case of basicAuth, it is set as the username.
-    tenant: 'mimir-continuous-test'
+    tenant: "mimir-continuous-test"
     # -- Password for basicAuth auth (note: can be environment variable from secret attached in extraEnvFrom, e.g. $(PASSWORD))
     # For GEM, it should contain an access token created for an access policy that allows `metrics:read` and `metrics:write` for the tenant.
     password: null

--- a/katalog/mimir/README.md
+++ b/katalog/mimir/README.md
@@ -16,7 +16,6 @@ Mimir is an open source, horizontally scalable, highly available, multi-tenant T
 
 - registry.sighup.io/fury/grafana/mimir
 - registry.sighup.io/fury/nginxinc/nginx-unprivileged
-- registry.sighup.io/fury/grafana/mimir-continuous-test
 
 ## Configuration
 

--- a/katalog/mimir/deploy.yaml
+++ b/katalog/mimir/deploy.yaml
@@ -845,7 +845,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: continuous-test
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=continuous-test"
@@ -942,7 +942,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: distributor
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -1070,7 +1070,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: gateway
-          image: docker.io/nginxinc/nginx-unprivileged:1.25-alpine
+          image: docker.io/nginxinc/nginx-unprivileged:1.27-alpine
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: nginx-config
@@ -1181,7 +1181,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: querier
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -1305,7 +1305,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: query-frontend
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -1425,7 +1425,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: query-scheduler
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -1608,7 +1608,7 @@ spec:
           emptyDir: {}
       containers:
         - name: compactor
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -1736,7 +1736,7 @@ spec:
           emptyDir: {}
       containers:
         - name: ingester
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -1872,7 +1872,7 @@ spec:
           emptyDir: {}
       containers:
         - name: store-gateway
-          image: "grafana/mimir:2.10.3"
+          image: "grafana/mimir:2.14.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/katalog/mimir/kustomization.yaml
+++ b/katalog/mimir/kustomization.yaml
@@ -37,10 +37,5 @@ patchesStrategicMerge:
 images:
   - name: docker.io/nginxinc/nginx-unprivileged
     newName: registry.sighup.io/fury/nginxinc/nginx-unprivileged
-    newTag: "1.25-alpine"
   - name: grafana/mimir
     newName: registry.sighup.io/fury/grafana/mimir
-    newTag: "2.11.0"
-  - name: grafana/mimir-continuous-test
-    newName: registry.sighup.io/fury/grafana/mimir-continuous-test
-    newTag: "2.11.0"


### PR DESCRIPTION
- Bump Mimir to v2.14.0 (latest from upstream), aligning it with the chart version included in #183
- Update Maintenance guide.
- Checked the release notes for 2.13.0 and 2.14.0, no changes to the config are needed.
- No special steps need to be taken for upgrading from previous version of the module, BUT **you can't upgrade directly to this version from versions including Mimir < 2.11.0**.
- Images have been synced in https://github.com/sighupio/fury-distribution-container-image-sync/pull/292