### PR TITLE
Feat/622 update x509 exporter for v1.32

### DIFF
--- a/katalog/x509-exporter/MAINTENANCE.md
+++ b/katalog/x509-exporter/MAINTENANCE.md
@@ -1,0 +1,23 @@
+# `x509-exporter` Package Maintenance
+
+To prepare a new release of this package:
+
+1. Get the current upstream release
+
+```bash
+mkdir temp && cd temp
+helm repo add enix https://charts.enix.io
+helm template x509-certificate-exporter enix/x509-certificate-exporter > manifests.yaml
+```
+
+2. Check the differences between `manifests.yaml` and the manifests within this repository tree, adjust everything accordingly.
+
+3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+
+4. Update each `kustomization.yaml` file with the new image.
+
+5. Remove the temporary directory
+
+```bash
+rm -rf temp
+```

--- a/katalog/x509-exporter/README.md
+++ b/katalog/x509-exporter/README.md
@@ -8,14 +8,14 @@ The original project is: [x509-certificate-exporter](https://github.com/enix/x50
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `v3.10.0`
+- Kubernetes >= `1.29.0`
+- Kustomize = `v5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 
 ## Image repository and tag
 
-- Certificate exporter image: `registry.sighup.io/fury/enix/x509-certificate-exporter:3.17.0`
+- Certificate exporter image: `registry.sighup.io/fury/enix/x509-certificate-exporter:3.18.1`
 
 ## Deployment
 

--- a/katalog/x509-exporter/daemonset/base/kustomization.yaml
+++ b/katalog/x509-exporter/daemonset/base/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: monitoring
 images:
   - name: docker.io/enix/x509-certificate-exporter
     newName: registry.sighup.io/fury/enix/x509-certificate-exporter
-    newTag: 3.17.0
+    newTag: 3.18.1
 
 resources:
   - daemonset.yml

--- a/katalog/x509-exporter/deployment/kustomization.yaml
+++ b/katalog/x509-exporter/deployment/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: monitoring
 images:
   - name: docker.io/enix/x509-certificate-exporter
     newName: registry.sighup.io/fury/enix/x509-certificate-exporter
-    newTag: 3.17.0
+    newTag: 3.18.1
 
 resources:
   - deployment.yml


### PR DESCRIPTION
This PR is part of the monitoring module upgrade for the fury 1.32 distribution release. It solves the issue https://github.com/sighupio/product-management/issues/622 

It bumps the x509-exporter image to v3.18.1 and adds a missing `MAINTENANCE.md` file. 

## Testing
The modifications have been both manually and automatically in a local environment using the drone pipeline. The quickest way is launching the e2e pipeline for the target Kubernetes version (in this case, 1.32) skipping the last step for cluster deletion `delete-kind-cluster` (just comment it temporarily).

```bash
drone exec --pipeline e2e-kubernetes-1.32 --trusted
```

Get the kubeconfig file and use it to inspect the status of the resources:

```bash
kind get kubeconfig --name cluster_name > /tmp/kubeconfig.yaml
export /tmp/kubeconfig.yaml
```

Check:
- if the x509 exporter daemonset rolled out correctly
- check its logs
- port-forward grafana and check if the metrics are visibile in the dedicated dashboard

Cleanup your environment with the command:

```bash
kind delete cluster --name cluster_name
```