### PR TITLE
Feat/620 update kube prometheus stack for v1.32

### DIFF
--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -16,19 +16,19 @@ COPY . .
 
 RUN npm install -g embedme@1.22.0 && /entrypoint.sh && embedme --verify "**/*.md"
 
-FROM golang:1.16 as add-license-requirement
+FROM golang:1.20 as add-license-requirement
 
-RUN go get -u github.com/google/addlicense && addlicense -c "SIGHUP s.r.l" -v -l bsd .
+RUN go install github.com/google/addlicense@v1.1.1 && addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" .
 
-FROM golang:1.16 as check-license
+FROM golang:1.20 as check-license
 
-RUN go get -u github.com/google/addlicense && mkdir /app
+RUN go install github.com/google/addlicense@v1.1.1 && mkdir /app
 
 WORKDIR /app
 
 COPY . .
 
-RUN addlicense -c "SIGHUP s.r.l" -v -l bsd --check .
+RUN addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" --check .
 
 FROM openpolicyagent/conftest:v0.28.1 as checklabel
 

--- a/katalog/aks-sm/README.md
+++ b/katalog/aks-sm/README.md
@@ -7,8 +7,8 @@ This package provides monitoring for Kubernetes components `kubelet`, `coredns` 
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Configuration

--- a/katalog/alertmanager-operated/README.md
+++ b/katalog/alertmanager-operated/README.md
@@ -13,14 +13,14 @@ with this package.
 
 ## Image repository and tag
 
-* Alertmanager image: `registry.sighup.io/prometheus/alertmanager:v0.26.0`
+* Alertmanager image: `registry.sighup.io/prometheus/alertmanager:v0.27.0`
 * Alertmanager repository: [Alertmanager on Github][am-gh]
 * Alertmanager documentation: [Alertmanager Homepage][am-doc]
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Configuration

--- a/katalog/alertmanager-operated/alertmanager.yaml
+++ b/katalog/alertmanager-operated/alertmanager.yaml
@@ -10,11 +10,11 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.26.0
+    app.kubernetes.io/version: 0.27.0
   name: main
   namespace: monitoring
 spec:
-  image: quay.io/prometheus/alertmanager:v0.26.0
+  image: quay.io/prometheus/alertmanager:v0.27.0
   # We set the matcher strategy to None, because otherwise the Prometheus
   # Operator will add a matcher to all routes checking for a namespace label
   # with the namespace where alertmanager is running.
@@ -28,7 +28,7 @@ spec:
       app.kubernetes.io/instance: main
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 0.26.0
+      app.kubernetes.io/version: 0.27.0
   replicas: 3
   resources:
     limits:
@@ -37,9 +37,10 @@ spec:
     requests:
       cpu: 4m
       memory: 100Mi
+  secrets: []
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: alertmanager-main
-  version: 0.26.0
+  version: 0.27.0

--- a/katalog/alertmanager-operated/kustomization.yaml
+++ b/katalog/alertmanager-operated/kustomization.yaml
@@ -17,7 +17,7 @@ patchesStrategicMerge:
     namespace: monitoring
   spec:
     alertmanagerConfigSelector: {}
-    image: registry.sighup.io/fury/prometheus/alertmanager:v0.26.0
+    image: registry.sighup.io/fury/prometheus/alertmanager:v0.27.0
     replicas: 1
 
 resources:

--- a/katalog/alertmanager-operated/prometheusRule.yaml
+++ b/katalog/alertmanager-operated/prometheusRule.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.26.0
+    app.kubernetes.io/version: 0.27.0
     prometheus: k8s
     role: alert-rules
   name: alertmanager-main-rules
@@ -54,7 +54,7 @@ spec:
         (
           rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring"}[5m])
         /
-          rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring"}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring"}[5m])
         )
         > 0.01
       for: 5m
@@ -69,7 +69,7 @@ spec:
         min by (namespace,service, integration) (
           rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring", integration=~`.*`}[5m])
         /
-          rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration=~`.*`}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration=~`.*`}[5m])
         )
         > 0.01
       for: 5m
@@ -84,7 +84,7 @@ spec:
         min by (namespace,service, integration) (
           rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring", integration!~`.*`}[5m])
         /
-          rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration!~`.*`}[5m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration!~`.*`}[5m])
         )
         > 0.01
       for: 5m

--- a/katalog/alertmanager-operated/service.yaml
+++ b/katalog/alertmanager-operated/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.26.0
+    app.kubernetes.io/version: 0.27.0
   name: alertmanager-main
   namespace: monitoring
 spec:

--- a/katalog/alertmanager-operated/serviceAccount.yaml
+++ b/katalog/alertmanager-operated/serviceAccount.yaml
@@ -11,6 +11,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.26.0
+    app.kubernetes.io/version: 0.27.0
   name: alertmanager-main
   namespace: monitoring

--- a/katalog/alertmanager-operated/serviceMonitor.yaml
+++ b/katalog/alertmanager-operated/serviceMonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.26.0
+    app.kubernetes.io/version: 0.27.0
   name: alertmanager-main
   namespace: monitoring
 spec:

--- a/katalog/blackbox-exporter/README.md
+++ b/katalog/blackbox-exporter/README.md
@@ -8,8 +8,8 @@ The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Image repository and tag

--- a/katalog/blackbox-exporter/clusterRoleBinding.yaml
+++ b/katalog/blackbox-exporter/clusterRoleBinding.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.25.0
   name: blackbox-exporter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/katalog/configs/aks/README.md
+++ b/katalog/configs/aks/README.md
@@ -5,8 +5,8 @@ This package provides monitoring for Kubernetes components `kubelet`, `coredns` 
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../../prometheus-operator)
 
 ## Configuration

--- a/katalog/configs/bases/coredns/service-monitors/coredns.yml
+++ b/katalog/configs/bases/coredns/service-monitors/coredns.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/katalog/configs/bases/default/service-monitors/apiserver.yml
+++ b/katalog/configs/bases/default/service-monitors/apiserver.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/katalog/configs/bases/default/service-monitors/kubelet.yml
+++ b/katalog/configs/bases/default/service-monitors/kubelet.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 

--- a/katalog/configs/eks/README.md
+++ b/katalog/configs/eks/README.md
@@ -5,8 +5,8 @@ This package provides monitoring for Kubernetes components `kubelet` and
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../../prometheus-operator)
 
 ## Configuration

--- a/katalog/configs/gke/README.md
+++ b/katalog/configs/gke/README.md
@@ -5,8 +5,8 @@ This package provides monitoring for Kubernetes components `kubelet` and
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../../prometheus-operator)
 
 ## Configuration

--- a/katalog/configs/kubeadm/README.md
+++ b/katalog/configs/kubeadm/README.md
@@ -16,8 +16,8 @@ Kubernetes.
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../../prometheus-operator)
 
 ## Configuration

--- a/katalog/eks-sm/README.md
+++ b/katalog/eks-sm/README.md
@@ -7,8 +7,8 @@ This package provides monitoring for Kubernetes components `kubelet` and
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Configuration

--- a/katalog/gke-sm/README.md
+++ b/katalog/gke-sm/README.md
@@ -7,8 +7,8 @@ This package provides monitoring for Kubernetes components `kubelet` and
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Configuration

--- a/katalog/grafana/README.md
+++ b/katalog/grafana/README.md
@@ -16,8 +16,8 @@ numeric time-series data with Prometheus integration.
 
 ## Requirements
 
-- Kubernetes >= `1.26.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 
 ## Configuration
 

--- a/katalog/karma/README.md
+++ b/katalog/karma/README.md
@@ -9,8 +9,8 @@ It can also aggregate alerts from multiple Alertmanager instances.
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize `= v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 - [prometheus-operated](../prometheus-operated)
 - [alertmanager-operated](../alertmanager-operated)

--- a/katalog/kube-proxy-metrics/README.md
+++ b/katalog/kube-proxy-metrics/README.md
@@ -11,14 +11,14 @@ by kube-proxy.
 
 ## Requirements
 
-- Kubernetes >= `1.24.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 
 ## Image repository and tag
 
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.14.0`
+- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.18.1`
 - kube-rbac-proxy repository: [kube-rbac-proxy on Github][krp-gh]
 
 

--- a/katalog/kube-state-metrics/README.md
+++ b/katalog/kube-state-metrics/README.md
@@ -21,8 +21,8 @@ From kube-state-metrics
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Image repository and tag

--- a/katalog/kubeadm-sm/README.md
+++ b/katalog/kubeadm-sm/README.md
@@ -23,8 +23,8 @@ Kubernetes.
 
 ## Requirements
 
-- Kubernetes >= `1.21.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Configuration

--- a/katalog/node-exporter/README.md
+++ b/katalog/node-exporter/README.md
@@ -8,8 +8,8 @@ enabled by default from the project's [repository][ne-gh]
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Image repository and tag

--- a/katalog/prometheus-adapter/README.md
+++ b/katalog/prometheus-adapter/README.md
@@ -14,8 +14,8 @@ It can also replace the [metrics server](https://github.com/kubernetes-incubator
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize `= v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 - [prometheus-operated](../prometheus-operated)
 

--- a/katalog/prometheus-operated/README.md
+++ b/katalog/prometheus-operated/README.md
@@ -15,8 +15,8 @@ Grafana. Grafana integration is provided in Fury monitoring katalog, please see
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator](../prometheus-operator)
 
 ## Image repository and tag

--- a/katalog/prometheus-operator/README.md
+++ b/katalog/prometheus-operator/README.md
@@ -39,8 +39,8 @@ illustrated in this image from Prometheus Operator repository:
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize = `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 
 ## Image repository and tag
 


### PR DESCRIPTION
This PR is part of the monitoring module upgrade for the fury 1.32 distribution release. It solves the issue https://github.com/sighupio/product-management/issues/620

- It bumps the alertmanager image to v0.27.0
- A bugfix in the helper dockerfile
- Adjustments in the README.md files in the packages

## Testing
The modifications have been both manually and automatically in a local environment using the drone pipeline. The quickest way is launching the e2e pipeline for the target Kubernetes version (in this case, 1.32) skipping the last step for cluster deletion `delete-kind-cluster` (just comment it temporarily).

```bash
drone exec --pipeline e2e-kubernetes-1.32 --trusted
```

Get the kubeconfig file and use it to inspect the status of the resources:

```bash
kind get kubeconfig --name cluster_name > /tmp/kubeconfig.yaml
export /tmp/kubeconfig.yaml
```

Check:
- if the alertmanager-main statefulset rolled out correctly
- check its logs
- port-forward alertmanager and check if the sections in the UI work as expected

Cleanup your environment with the command:

```bash
kind delete cluster --name cluster_name
```