### PR TITLE
Feat/623 update minio for 1.32

### DIFF
--- a/katalog/minio-ha/MAINTENANCE.md
+++ b/katalog/minio-ha/MAINTENANCE.md
@@ -9,7 +9,7 @@ Extract to a folder of your choice, for example: `/tmp/minio`.
 Run the following command:
 
 ```bash
-helm template minio-logging /tmp/minio/helm/minio --values MAINTENANCE.values.yaml -n logging > minio-built.yaml
+helm template minio-monitoring /tmp/minio/helm/minio --values MAINTENANCE.values.yaml -n monitoring > minio-built.yaml
 ```
 
 Minio's helm comes packaged with a specific mc (its client) version, to find out

--- a/katalog/minio-ha/README.md
+++ b/katalog/minio-ha/README.md
@@ -8,8 +8,8 @@ In order to achieve high availability (HA) for MinIO, a cluster of multiple MinI
 
 ## Requirements
 
-- Kubernetes >= `1.23.0`
-- Kustomize >= `v3.5.3`
+- Kubernetes >= `1.29.0`
+- Kustomize = `5.6.0`
 - [prometheus-operator from KFD monitoring module][prometheus-operator]
 
 > Prometheus Operator is necessary since we configure a `ServiceMonitor` to make

--- a/katalog/minio-ha/deploy.yaml
+++ b/katalog/minio-ha/deploy.yaml
@@ -16,7 +16,7 @@ metadata:
   name: minio-monitoring-console
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-monitoring
     heritage: Helm
 spec:
@@ -37,7 +37,7 @@ metadata:
   name: minio-monitoring
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-monitoring
     heritage: Helm
     monitoring: "true"
@@ -59,7 +59,7 @@ metadata:
   name: minio-monitoring-svc
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-monitoring
     heritage: Helm
 spec:
@@ -81,7 +81,7 @@ metadata:
   name: minio-monitoring
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-monitoring
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ spec:
       serviceAccountName: minio-sa
       containers:
         - name: minio
-          image: registry.sighup.io/fury/minio:RELEASE.2024-04-18T19-09-19Z
+          image: registry.sighup.io/fury/minio:RELEASE.2024-10-13T13-34-11Z
           imagePullPolicy: IfNotPresent
           command: [
             "/bin/sh",
@@ -132,7 +132,7 @@ spec:
             - name: export-0
               mountPath: /export-0
             - name: export-1
-              mountPath: /export-1
+              mountPath: /export-1            
           ports:
             - name: http
               containerPort: 9000
@@ -188,7 +188,7 @@ metadata:
   name: minio-monitoring-cluster
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-monitoring
     heritage: Helm
 spec:
@@ -209,7 +209,7 @@ metadata:
   name: minio-monitoring
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-monitoring
     heritage: Helm
 spec:

--- a/katalog/minio-ha/deploy.yaml
+++ b/katalog/minio-ha/deploy.yaml
@@ -132,7 +132,7 @@ spec:
             - name: export-0
               mountPath: /export-0
             - name: export-1
-              mountPath: /export-1            
+              mountPath: /export-1
           ports:
             - name: http
               containerPort: 9000

--- a/katalog/minio-ha/kustomization.yaml
+++ b/katalog/minio-ha/kustomization.yaml
@@ -17,9 +17,9 @@ images:
   - name: registry.sighup.io/fury/groundnuty/k8s-wait-for
     newTag: v2.0
   - name: registry.sighup.io/fury/minio/mc
-    newTag: RELEASE.2024-10-08T09-37-26Z
+    newTag: RELEASE.2025-02-28T09-55-16Z
   - name: registry.sighup.io/fury/minio
-    newTag: RELEASE.2024-10-13T13-34-11Z
+    newTag: RELEASE.2025-02-28T09-55-16Z
 
 secretGenerator:
   - name: minio-monitoring

--- a/katalog/minio-ha/kustomization.yaml
+++ b/katalog/minio-ha/kustomization.yaml
@@ -17,7 +17,7 @@ images:
   - name: registry.sighup.io/fury/groundnuty/k8s-wait-for
     newTag: v2.0
   - name: registry.sighup.io/fury/minio/mc
-    newTag: RELEASE.2025-02-28T09-55-16Z
+    newTag: RELEASE.2025-02-21T16-00-46Z
   - name: registry.sighup.io/fury/minio
     newTag: RELEASE.2025-02-28T09-55-16Z
 


### PR DESCRIPTION
This PR is part of the monitoring module upgrade for the fury 1.32 distribution release. It solves the issue https://github.com/sighupio/product-management/issues/623

Updates minio to RELEASE.2025-02-28T09-55-16Z

Some minor changes