### PR TITLE
Add probes to x509-exporter daemonsets

### DIFF
--- a/katalog/x509-exporter/daemonset/base/daemonset.yml
+++ b/katalog/x509-exporter/daemonset/base/daemonset.yml
@@ -41,6 +41,18 @@ spec:
           ports:
             - name: metrics
               containerPort: 9793
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            httpGet:
+              path: /healthz
+              port: metrics
+          livenessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            httpGet:
+              path: /healthz
+              port: metrics
           volumeMounts:
             - name: etc-kubernetes
               mountPath: /etc/kubernetes


### PR DESCRIPTION
### Summary 💡

This PR adds liveness and readiness probes to the x509-exporter control-plane and data-plane DaemonSets to ensure consistency with upstream configurations.

Closes #214


### Description 📝

Starting from x509-certificate-exporter v3.19.1, the upstream chart introduced health probes for the Deployment and Daemonset.
The monitoring v4.0.0 module inherited those defaults, but the DaemonSets (control-plane and data-plane) were missing probes entirely.

This PR:
	•	Adds both readiness and liveness probes to the DaemonSets using the same endpoints and basic structure from upstream.
	•	Keeps all probe timings identical to upstream defaults — no changes to initialDelaySeconds.


### Tests performed 🧪

- [x] Create a SD cluster using the new monitoring module
- [x] All x509-exporter DaemonSet are successfully deployed with liveness and readiness probes correctly configured. Relative pods are Running 

