### PR TITLE
fix(kubeadm): use etcd_mvcc_db_total_size_in_bytes metric in etcd Grafana dashboard

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,7 @@
+# Monitoring Module Release TDB
+
+Welcome to the latest release of the `monitoring` core module of the [`SIGHUP Distribution`](https://github.com/sighupio/distribution), maintained by team SIGHUP by ReeVo.
+
+## Bug Fixes 🐞
+
+- [[#220](https://github.com/sighupio/module-monitoring/pull/220)] Updates the deprecated etcd_debugging_mvcc_db_total_size_in_bytes Prometheus metric to the promoted etcd_mvcc_db_total_size_in_bytes to fix the "Database Size" panel in the etcd Grafana dashboard.

--- a/katalog/configs/kubeadm/dashboards/etcd.json
+++ b/katalog/configs/kubeadm/dashboards/etcd.json
@@ -348,7 +348,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "etcd_debugging_mvcc_db_total_size_in_bytes{job=\"$cluster\"}",
+          "expr": "etcd_mvcc_db_total_size_in_bytes{job=\"$cluster\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
### Summary 💡

Fixes the "Database Size" panel in the etcd Grafana dashboard.

Closes: https://github.com/sighupio/module-monitoring/issues/219

### Description 📝

Panel queries `etcd_debugging_mvcc_db_total_size_in_bytes`, removed in etcd v3.5 in favour of `etcd_mvcc_db_total_size_in_bytes`.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Grafana etcd dashboard "Database Size" panel shows data after the fix

### Future work 🔧

None