### PR TITLE
feat: add E2E tests for K8S 1.35

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,7 +79,7 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.33.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.35.0
     environment:
       KUBERNETES_MANIFESTS: alertmanager-operated.yml
 
@@ -188,285 +188,6 @@ steps:
       event:
         - push
         - tag
-
----
-name: E2E Tests on kind clusters version 1.29.8
-kind: pipeline
-type: docker
-platform:
-  os: linux
-  arch: amd64
-depends_on:
-  - linting
-clone:
-  depth: 1
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-environment:
-  # Mise configuration
-  MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
-  KIND_VERSION: "0.29.0"
-  KUBECTL_VERSION: "1.29.1"
-  BATS_VERSION: "1.11.0"
-  CLUSTER_VERSION: "1.29.8"
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
-  - name: mise-cache
-    host:
-      path: /root/mise_data_dir
-
-steps:
-  - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - clone
-    commands:
-      - mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 yq@4.43.1
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/create-e2e-cluster.sh $${CLUSTER_VERSION}
-
-  - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - Create Kind Cluster
-    commands:
-      - mise use bats@$${BATS_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 kapp@0.64.2
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/run-monitoring-tests.sh
-
-  - name: Delete Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - Run E2E Tests
-    when:
-      status:
-        - success
-        - failure
-    commands:
-      - mise use kind@$${KIND_VERSION}
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/cleanup-e2e-cluster.sh || true
-
----
-name: E2E Tests on kind clusters version 1.30.4
-kind: pipeline
-type: docker
-platform:
-  os: linux
-  arch: amd64
-depends_on:
-  - linting
-clone:
-  depth: 1
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-environment:
-  # Mise configuration
-  MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
-  KIND_VERSION: "0.29.0"
-  KUBECTL_VERSION: "1.30.4"
-  BATS_VERSION: "1.11.0"
-  CLUSTER_VERSION: "1.30.4"
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
-  - name: mise-cache
-    host:
-      path: /root/mise_data_dir
-
-steps:
-  - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - clone
-    commands:
-      - mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 yq@4.43.1
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/create-e2e-cluster.sh $${CLUSTER_VERSION}
-
-  - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - Create Kind Cluster
-    commands:
-      - mise use bats@$${BATS_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 kapp@0.64.2
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/run-monitoring-tests.sh
-
-  - name: Delete Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - Run E2E Tests
-    when:
-      status:
-        - success
-        - failure
-    commands:
-      - mise use kind@$${KIND_VERSION}
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/cleanup-e2e-cluster.sh || true
-
----
-name: E2E Tests on kind clusters version 1.31.1
-kind: pipeline
-type: docker
-platform:
-  os: linux
-  arch: amd64
-depends_on:
-  - linting
-clone:
-  depth: 1
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-environment:
-  # Mise configuration
-  MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
-  KIND_VERSION: "0.29.0"
-  KUBECTL_VERSION: "1.31.1"
-  BATS_VERSION: "1.11.0"
-  CLUSTER_VERSION: "1.31.1"
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
-  - name: mise-cache
-    host:
-      path: /root/mise_data_dir
-
-steps:
-  - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - clone
-    commands:
-      - mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 yq@4.43.1
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/create-e2e-cluster.sh $${CLUSTER_VERSION}
-
-  - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - Create Kind Cluster
-    commands:
-      - mise use bats@$${BATS_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 kapp@0.64.2
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/run-monitoring-tests.sh
-
-  - name: Delete Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
-    pull: always
-    network_mode: host
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-      - name: mise-cache
-        path: /mise-data
-    depends_on:
-      - Run E2E Tests
-    when:
-      status:
-        - success
-        - failure
-    commands:
-      - mise use kind@$${KIND_VERSION}
-      - eval "$(mise activate bash --shims)"
-      - ./scripts/cleanup-e2e-cluster.sh || true
 
 ---
 name: E2E Tests on kind clusters version 1.32.2
@@ -748,6 +469,99 @@ steps:
       - ./scripts/cleanup-e2e-cluster.sh || true
 
 ---
+name: E2E Tests on kind clusters version 1.35.0
+kind: pipeline
+type: docker
+platform:
+  os: linux
+  arch: amd64
+depends_on:
+  - linting
+clone:
+  depth: 1
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+environment:
+  # Mise configuration
+  MISE_DATA_DIR: "/mise-data"
+  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+  KIND_VERSION: "0.31.0"
+  KUBECTL_VERSION: "1.35.5"
+  BATS_VERSION: "1.11.0"
+  CLUSTER_VERSION: "1.35.0"
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+
+steps:
+  - name: Create Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - clone
+    commands:
+      - mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 yq@4.43.1
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/create-e2e-cluster.sh $${CLUSTER_VERSION}
+
+  - name: Run E2E Tests
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - Create Kind Cluster
+    commands:
+      - mise use bats@$${BATS_VERSION} kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 kapp@0.64.2
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/run-monitoring-tests.sh
+
+  - name: Delete Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - Run E2E Tests
+    when:
+      status:
+        - success
+        - failure
+    commands:
+      - mise use kind@$${KIND_VERSION}
+      - eval "$(mise activate bash --shims)"
+      - ./scripts/cleanup-e2e-cluster.sh || true
+
+---
 name: release
 kind: pipeline
 type: docker
@@ -756,12 +570,10 @@ node:
 clone:
   depth: 1
 depends_on:
-  - E2E Tests on kind clusters version 1.29.8
-  - E2E Tests on kind clusters version 1.30.4
-  - E2E Tests on kind clusters version 1.31.1
   - E2E Tests on kind clusters version 1.32.2
   - E2E Tests on kind clusters version 1.33.0
   - E2E Tests on kind clusters version 1.34.0
+  - E2E Tests on kind clusters version 1.35.0
 platform:
   os: linux
   arch: amd64

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 katalog/tests/workspace/
 katalog/tests/.vagrant/
+/.idea/

--- a/mise.toml
+++ b/mise.toml
@@ -3,8 +3,8 @@
 # license that can be found in the LICENSE file.
 
 [tools]
-kind = "0.29.0"
-kubectl = "1.34.0"
+kind = "0.31.0"
+kubectl = "1.35.5"
 kustomize = "5.6.0"
 helm = "3.15.0"
 yq = "4.43.1"

--- a/utils/pull-upstream.sh
+++ b/utils/pull-upstream.sh
@@ -203,4 +203,6 @@ case "${FURY_MODULE}" in
     ;;
 esac
 
+mise run add-license
+
 exit 0


### PR DESCRIPTION
### Summary 💡

Add E2E tests for K8S 1.35, drop the support for <1.32.

### Description 📝

Update kind, kubectl, add tests for 1.35 and drop tests for <1.32.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2561

### Future work 🔧

Update aks-sm component.