### PR TITLE
feat: upgrade aks-sm with kube-prometheus v0.17.0

### DIFF
--- a/katalog/aks-sm/MAINTENANCE.md
+++ b/katalog/aks-sm/MAINTENANCE.md
@@ -4,11 +4,10 @@ To prepare a new release of this package:
 
 1. Get the current upstream release
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} aks-sm
-```
+   ```bash
+   export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} aks-sm
+   ```
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
-Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
-
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`

--- a/katalog/configs/bases/default/service-monitors/apiserver.yml
+++ b/katalog/configs/bases/default/service-monitors/apiserver.yml
@@ -25,7 +25,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers|storage_db_total_size_in_bytes|flowcontrol_request_concurrency_limit|flowcontrol_request_concurrency_in_use)
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers|storage_db_total_size_in_bytes|flowcontrol_request_concurrency_limit|flowcontrol_request_concurrency_in_use|storage_objects)
       sourceLabels:
       - __name__
     - action: drop

--- a/katalog/configs/bases/default/service-monitors/kubelet.yml
+++ b/katalog/configs/bases/default/service-monitors/kubelet.yml
@@ -26,7 +26,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers|storage_db_total_size_in_bytes|flowcontrol_request_concurrency_limit|flowcontrol_request_concurrency_in_use)
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers|storage_db_total_size_in_bytes|flowcontrol_request_concurrency_limit|flowcontrol_request_concurrency_in_use|storage_objects)
       sourceLabels:
       - __name__
     - action: drop

--- a/katalog/configs/kubeadm/service-monitors/controller-manager.yml
+++ b/katalog/configs/kubeadm/service-monitors/controller-manager.yml
@@ -25,7 +25,7 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers|storage_db_total_size_in_bytes|flowcontrol_request_concurrency_limit|flowcontrol_request_concurrency_in_use)
+      regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs|longrunning_gauge|registered_watchers|storage_db_total_size_in_bytes|flowcontrol_request_concurrency_limit|flowcontrol_request_concurrency_in_use|storage_objects)
       sourceLabels:
       - __name__
     - action: drop


### PR DESCRIPTION
### Summary 💡

Update aks-sm with kube-prometheus v0.17.0

### Description 📝

Update aks-sm with kube-prometheus v0.17.0

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2567

### Future work 🔧

Update alertmanager-exporter component.
