### PR TITLE
feat: upgrade alertmanager-operated with kube-prometheus v0.17.0

### DIFF
--- a/katalog/alertmanager-operated/MAINTENANCE.md
+++ b/katalog/alertmanager-operated/MAINTENANCE.md
@@ -4,14 +4,14 @@ To prepare a new release of this package:
 
 1. Get the current upstream release
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} alertmanager-operated
-```
+   ```bash
+     export KUBE_PROMETHEUS_RELEASE=v0.17.0
+     ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} alertmanager-operated
+   ```
+   
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
-  Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
-
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 

--- a/katalog/alertmanager-operated/alertmanager.yaml
+++ b/katalog/alertmanager-operated/alertmanager.yaml
@@ -10,11 +10,12 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.28.1
+    app.kubernetes.io/version: 0.31.1
   name: main
   namespace: monitoring
 spec:
-  image: quay.io/prometheus/alertmanager:v0.28.1
+  alertmanagerConfigSelector: {}
+  image: quay.io/prometheus/alertmanager:v0.31.1
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:
@@ -23,7 +24,7 @@ spec:
       app.kubernetes.io/instance: main
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 0.28.1
+      app.kubernetes.io/version: 0.31.1
   replicas: 3
   resources:
     limits:
@@ -38,4 +39,4 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: alertmanager-main
-  version: 0.28.1
+  version: 0.31.1

--- a/katalog/alertmanager-operated/kustomization.yaml
+++ b/katalog/alertmanager-operated/kustomization.yaml
@@ -23,7 +23,7 @@ patches:
         # https://github.com/sighupio/module-monitoring/issues/132
         alertmanagerConfigMatcherStrategy:
           type: None
-        image: registry.sighup.io/fury/prometheus/alertmanager:v0.28.1
+        image: registry.sighup.io/fury/prometheus/alertmanager:v0.31.1
         replicas: 1
 
 resources:

--- a/katalog/alertmanager-operated/prometheusRule.yaml
+++ b/katalog/alertmanager-operated/prometheusRule.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.28.1
+    app.kubernetes.io/version: 0.31.1
     prometheus: k8s
     role: alert-rules
   name: alertmanager-main-rules
@@ -27,7 +27,7 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring"}[5m]) == 0
+        max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m]) == 0
       for: 10m
       labels:
         severity: critical
@@ -39,9 +39,9 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-          max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring"}[5m])
+          max_over_time(alertmanager_cluster_members{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m])
         < on (namespace,service) group_left
-          count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring"}[5m]))
+          count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m]))
       for: 15m
       labels:
         severity: critical
@@ -52,9 +52,9 @@ spec:
         summary: An Alertmanager instance failed to send notifications.
       expr: |
         (
-          rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring"}[15m])
+          rate(alertmanager_notifications_failed_total{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring"}[15m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[15m])
         )
         > 0.01
       for: 5m
@@ -67,9 +67,9 @@ spec:
         summary: All Alertmanager instances in a cluster failed to send notifications to a critical integration.
       expr: |
         min by (namespace,service, integration) (
-          rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring", integration=~`.*`}[15m])
+          rate(alertmanager_notifications_failed_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration=~`.*`}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration=~`.*`}[15m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration=~`.*`}[15m]) > 0
         )
         > 0.01
       for: 5m
@@ -82,9 +82,9 @@ spec:
         summary: All Alertmanager instances in a cluster failed to send notifications to a non-critical integration.
       expr: |
         min by (namespace,service, integration) (
-          rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring", integration!~`.*`}[15m])
+          rate(alertmanager_notifications_failed_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration!~`.*`}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration!~`.*`}[15m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration!~`.*`}[15m]) > 0
         )
         > 0.01
       for: 5m
@@ -97,7 +97,7 @@ spec:
         summary: Alertmanager instances within the same cluster have different configurations.
       expr: |
         count by (namespace,service) (
-          count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="monitoring"})
+          count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="alertmanager-main",container="alertmanager",namespace="monitoring"})
         )
         != 1
       for: 20m
@@ -111,11 +111,11 @@ spec:
       expr: |
         (
           count by (namespace,service) (
-            avg_over_time(up{job="alertmanager-main",namespace="monitoring"}[5m]) < 0.5
+            avg_over_time(up{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m]) < 0.5
           )
         /
           count by (namespace,service) (
-            up{job="alertmanager-main",namespace="monitoring"}
+            up{job="alertmanager-main",container="alertmanager",namespace="monitoring"}
           )
         )
         >= 0.5
@@ -130,11 +130,11 @@ spec:
       expr: |
         (
           count by (namespace,service) (
-            changes(process_start_time_seconds{job="alertmanager-main",namespace="monitoring"}[10m]) > 4
+            changes(process_start_time_seconds{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[10m]) > 4
           )
         /
           count by (namespace,service) (
-            up{job="alertmanager-main",namespace="monitoring"}
+            up{job="alertmanager-main",container="alertmanager",namespace="monitoring"}
           )
         )
         >= 0.5

--- a/katalog/alertmanager-operated/service.yaml
+++ b/katalog/alertmanager-operated/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.28.1
+    app.kubernetes.io/version: 0.31.1
   name: alertmanager-main
   namespace: monitoring
 spec:

--- a/katalog/alertmanager-operated/serviceAccount.yaml
+++ b/katalog/alertmanager-operated/serviceAccount.yaml
@@ -11,6 +11,6 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.28.1
+    app.kubernetes.io/version: 0.31.1
   name: alertmanager-main
   namespace: monitoring

--- a/katalog/alertmanager-operated/serviceMonitor.yaml
+++ b/katalog/alertmanager-operated/serviceMonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.28.1
+    app.kubernetes.io/version: 0.31.1
   name: alertmanager-main
   namespace: monitoring
 spec:


### PR DESCRIPTION
### Summary 💡

Update alertmanager-operated to v0.31.1 with kube-prometheus v0.17.0

### Description 📝

Update alertmanager-operated to v0.31.1 with kube-prometheus v0.17.0

### Breaking Changes 💔

Not detected.

Analysis of [changelogs](https://github.com/prometheus/alertmanager/releases):
- 0.29.0 has no `[CHANGE]` entries.
- 0.30.0
  - https://github.com/prometheus/alertmanager/pull/4707: we are not affected.
- 0.30.1 has no `[CHANGE]` entries.
- 0.31.0 has no `[CHANGE]` entries.
- 0.31.1 has no `[CHANGE]` entries.


### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2570

I also tested updating the manifests from the old to the new one.

### Future work 🔧

Upgrade blackbox-exporter component.
