### PR TITLE
feat: update blackbox-exporter to 0.28.0 with helm chart v0.17.0

### DIFF
--- a/katalog/blackbox-exporter/MAINTENANCE.md
+++ b/katalog/blackbox-exporter/MAINTENANCE.md
@@ -4,14 +4,14 @@ To prepare a new release of this package:
 
 1. Get the current upstream release
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} blackbox-exporter
-```
+   ```bash
+   export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} blackbox-exporter
+   ```
+   
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
-Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
-
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
 

--- a/katalog/blackbox-exporter/clusterRole.yaml
+++ b/katalog/blackbox-exporter/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.27.0
+    app.kubernetes.io/version: 0.28.0
   name: blackbox-exporter
 rules:
 - apiGroups:

--- a/katalog/blackbox-exporter/clusterRoleBinding.yaml
+++ b/katalog/blackbox-exporter/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.27.0
+    app.kubernetes.io/version: 0.28.0
   name: blackbox-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/katalog/blackbox-exporter/configuration.yaml
+++ b/katalog/blackbox-exporter/configuration.yaml
@@ -50,6 +50,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.27.0
+    app.kubernetes.io/version: 0.28.0
   name: blackbox-exporter-configuration
   namespace: monitoring

--- a/katalog/blackbox-exporter/deployment.yaml
+++ b/katalog/blackbox-exporter/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.27.0
+    app.kubernetes.io/version: 0.28.0
   name: blackbox-exporter
   namespace: monitoring
 spec:
@@ -27,14 +27,14 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: blackbox-exporter
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 0.27.0
+        app.kubernetes.io/version: 0.28.0
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
         - --config.file=/etc/blackbox_exporter/config.yml
         - --web.listen-address=:19115
-        image: quay.io/prometheus/blackbox-exporter:v0.27.0
+        image: quay.io/prometheus/blackbox-exporter:v0.28.0
         name: blackbox-exporter
         ports:
         - containerPort: 19115
@@ -90,7 +90,7 @@ spec:
         - --secure-listen-address=:9115
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:19115/
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9115

--- a/katalog/blackbox-exporter/kustomization.yaml
+++ b/katalog/blackbox-exporter/kustomization.yaml
@@ -11,12 +11,16 @@ namespace: monitoring
 images:
   - name: quay.io/prometheus/blackbox-exporter
     newName: registry.sighup.io/fury/prometheus/blackbox-exporter
-  - name: jimmidyson/configmap-reload
-    newName: registry.sighup.io/fury/jimmidyson/configmap-reload
+    newTag: v0.28.0
   - name: quay.io/brancz/kube-rbac-proxy
     newName: registry.sighup.io/fury/brancz/kube-rbac-proxy
+    newTag: v0.21.0
   - name: ghcr.io/jimmidyson/configmap-reload
     newName: registry.sighup.io/fury/jimmidyson/configmap-reload
+    newTag: v0.15.0
+  - name: jimmidyson/configmap-reload
+    newName: registry.sighup.io/fury/jimmidyson/configmap-reload
+    newTag: v0.15.0
 resources:
   - clusterRole.yaml
   - clusterRoleBinding.yaml

--- a/katalog/blackbox-exporter/service.yaml
+++ b/katalog/blackbox-exporter/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.27.0
+    app.kubernetes.io/version: 0.28.0
   name: blackbox-exporter
   namespace: monitoring
 spec:

--- a/katalog/blackbox-exporter/serviceAccount.yaml
+++ b/katalog/blackbox-exporter/serviceAccount.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.27.0
+    app.kubernetes.io/version: 0.28.0
   name: blackbox-exporter
   namespace: monitoring

--- a/katalog/blackbox-exporter/serviceMonitor.yaml
+++ b/katalog/blackbox-exporter/serviceMonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.27.0
+    app.kubernetes.io/version: 0.28.0
   name: blackbox-exporter
   namespace: monitoring
 spec:


### PR DESCRIPTION
### Summary 💡

Update blackbox-exporter to 0.28.0 with helm chart v0.17.0.


### Description 📝

Update blackbox-exporter to 0.28.0 with helm chart v0.17.0.

### Breaking Changes 💔

Changes from [blackbox-exporter](https://github.com/prometheus/blackbox_exporter/releases):

| Version | Breaking Change | Reason Not Affected |
|---------|----------------|---------------------|
| 0.28.0 | **`--log.prober` flag behavior changed.** Probe logger is now independent. Logs previously at `INFO` moved to `DEBUG`, errors moved to `ERROR`. | `--log.prober` is not set in `deployment.yaml:34-36`. Only `--config.file` and `--web.listen-address` are configured. No log parsing or alerting depends on specific log levels. |
| 0.28.0 | **Log leveling improved.** Errors at `ERROR` instead of `INFO`, many prober logs from `INFO` to `DEBUG`. | No dashboards or alerts depend on blackbox-exporter log levels. |

kube-rbac-proxy has no breaking changes.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2578

I also tested updating the manifests from the old to the new one.

### Future work 🔧

Update the eks-sm component.
