### PR TITLE
feat: upgrade eks-sm with kube-prometheus v0.17.0

### DIFF
--- a/katalog/eks-sm/MAINTENANCE.md
+++ b/katalog/eks-sm/MAINTENANCE.md
@@ -4,11 +4,11 @@ To prepare a new release of this package:
 
 1. Get the current upstream release
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} eks-sm
-```
+   ```bash
+   export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} eks-sm
+   ```
 
-Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`

--- a/katalog/eks-sm/README.md
+++ b/katalog/eks-sm/README.md
@@ -13,7 +13,7 @@ This package provides monitoring for Kubernetes components `kubelet` and
 
 ## Configuration
 
-Fury distribution EKS ServiceMonitor has following configuration:
+Fury distribution EKS ServiceMonitor has the following configuration:
 
 - `api-server` and `kubelet` metrics are scraped with `30s` intervals
 - `coredns` metrics are scraped with `15s` intervals


### PR DESCRIPTION
### Summary 💡

Update eks-sm with kube-prometheus v0.17.0

### Description 📝

Update eks-sm with kube-prometheus v0.17.0.
It's a PR "label" to track that the upgrade has been done even without changes

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2579

### Future work 🔧

Update gke-sm component.
