### PR TITLE
feat: upgrade kube-state-metrics to v2.18.0 with helm chart 0.17.0

### DIFF
--- a/katalog/kube-state-metrics/MAINTENANCE.md
+++ b/katalog/kube-state-metrics/MAINTENANCE.md
@@ -4,15 +4,17 @@ To prepare a new release of this package:
 
 1. Get the current upstream release
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} kube-state-metrics
-```
+   ```bash
+   export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} kube-state-metrics
+   ```
 
-Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
+
+5. Note on `--resources` flag: kube-state-metrics 2.18.0 replaced `endpoints` with `endpointslices` as the default resource. The flag `--resources=endpoints,endpointslices` is required to keep `kube_endpoint_address` metrics (used by `MimirGossipMembersEndpointsOutOfSync` alert in `katalog/mimir/prometheusRules.yaml`). Without this flag, the alert breaks because `kube_endpoint_address` is no longer emitted.

--- a/katalog/kube-state-metrics/clusterRole.yaml
+++ b/katalog/kube-state-metrics/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.16.0
+    app.kubernetes.io/version: 2.18.0
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/katalog/kube-state-metrics/clusterRoleBinding.yaml
+++ b/katalog/kube-state-metrics/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.16.0
+    app.kubernetes.io/version: 2.18.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/katalog/kube-state-metrics/deployment.yaml
+++ b/katalog/kube-state-metrics/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.16.0
+    app.kubernetes.io/version: 2.18.0
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -27,16 +27,17 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 2.16.0
+        app.kubernetes.io/version: 2.18.0
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
         - --host=127.0.0.1
         - --port=8081
+        - --resources=endpoints,endpointslices
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
         name: kube-state-metrics
         resources:
           limits:
@@ -60,7 +61,7 @@ spec:
         - --secure-listen-address=:8443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:8081/
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.0
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -87,7 +88,7 @@ spec:
         - --secure-listen-address=:9443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:8082/
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.0
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443

--- a/katalog/kube-state-metrics/kustomization.yaml
+++ b/katalog/kube-state-metrics/kustomization.yaml
@@ -11,8 +11,10 @@ namespace: monitoring
 images:
   - name: registry.k8s.io/kube-state-metrics/kube-state-metrics
     newName: registry.sighup.io/fury/kube-state-metrics/kube-state-metrics
+    newTag: v2.18.0
   - name: quay.io/brancz/kube-rbac-proxy
     newName: registry.sighup.io/fury/brancz/kube-rbac-proxy
+    newTag: v0.21.0
 
 patches:
   - patch: |-

--- a/katalog/kube-state-metrics/prometheusRule.yaml
+++ b/katalog/kube-state-metrics/prometheusRule.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.16.0
+    app.kubernetes.io/version: 2.18.0
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/katalog/kube-state-metrics/service.yaml
+++ b/katalog/kube-state-metrics/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.16.0
+    app.kubernetes.io/version: 2.18.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/katalog/kube-state-metrics/serviceAccount.yaml
+++ b/katalog/kube-state-metrics/serviceAccount.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.16.0
+    app.kubernetes.io/version: 2.18.0
   name: kube-state-metrics
   namespace: monitoring

--- a/katalog/kube-state-metrics/serviceMonitor.yaml
+++ b/katalog/kube-state-metrics/serviceMonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.16.0
+    app.kubernetes.io/version: 2.18.0
   name: kube-state-metrics
   namespace: monitoring
 spec:


### PR DESCRIPTION
### Summary 💡

Upgrade kube-state-metrics to v2.18.0 with helm chart 0.17.0.

### Description 📝

Upgrade kube-state-metrics to v2.18.0 with helm chart 0.17.0.

### Breaking Changes 💔

Handled.


| Version | Breaking Change | Action |
|---------|----------------|---------------------|
| 2.18.0 | `endpoints` resource replaced by `endpointslices` as default |`kube_endpoint_address` metric is used by Mimir mixin alert `MimirGossipMembersEndpointsOutOfSync` in `katalog/mimir/prometheusRules.yaml:647,652,669,674`. Set the flag `--resources=endpoints,endpointslices` |


### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2635

I also tested updating the manifests from the old to the new one.

### Future work 🔧

Update kubeadm-sm component.
