### PR TITLE
feat: upgrade kube-proxy-metrics to 0.22.0

### DIFF
--- a/katalog/kube-proxy-metrics/MAINTENANCE.md
+++ b/katalog/kube-proxy-metrics/MAINTENANCE.md
@@ -1,0 +1,15 @@
+# `kube-proxy-metrics` Package Maintenance
+
+To prepare a new release of this package:
+
+1. Run the upgrade script to bump the `kube-rbac-proxy` image to the latest release:
+
+   ```bash
+   ./upgrade.sh
+   ```
+
+2. Check the differences introduced in `kustomization.yaml` and verify the new tag.
+
+3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+
+4. Update the image tag in `README.md` to reflect the new version.

--- a/katalog/kube-proxy-metrics/MAINTENANCE.md
+++ b/katalog/kube-proxy-metrics/MAINTENANCE.md
@@ -10,6 +10,6 @@ To prepare a new release of this package:
 
 2. Check the differences introduced in `kustomization.yaml` and verify the new tag.
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the image tag in `README.md` to reflect the new version.

--- a/katalog/kube-proxy-metrics/README.md
+++ b/katalog/kube-proxy-metrics/README.md
@@ -17,7 +17,7 @@ by kube-proxy.
 
 ## Image repository and tag
 
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.19.1`
+- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.22.0`
 - kube-rbac-proxy repository: [kube-rbac-proxy on Github][krp-gh]
 
 ## Configuration

--- a/katalog/kube-proxy-metrics/kustomization.yaml
+++ b/katalog/kube-proxy-metrics/kustomization.yaml
@@ -5,14 +5,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: monitoring
-
 images:
   - name: kube-rbac-proxy
     newName: registry.sighup.io/fury/brancz/kube-rbac-proxy
-    newTag: v0.19.1
-
+    newTag: v0.22.0
 resources:
   - dashboards
   - deploy.yml

--- a/katalog/kube-proxy-metrics/upgrade.sh
+++ b/katalog/kube-proxy-metrics/upgrade.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -euo pipefail
+
+RBAC_PROXY_RELEASE=$(curl -sL "https://api.github.com/repos/kube-rbac-proxy/kube-rbac-proxy/releases/latest" | jq -r ".tag_name")
+echo "Found latest Kube RBAC Proxy ${RBAC_PROXY_RELEASE}"
+
+yq -i "(.images[] | select(.name == \"kube-rbac-proxy\")).newTag = \"${RBAC_PROXY_RELEASE}\"" kustomization.yaml
+echo "Kube RBAC proxy updated to ${RBAC_PROXY_RELEASE}"


### PR DESCRIPTION
### Summary 💡

Upgrade kube-proxy-metrics to 0.22.0.


### Description 📝

Upgrade kube-proxy-metrics to 0.22.0.
Added utility script to upgrade.

### Breaking Changes 💔

Not detected

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2634

### Future work 🔧

Update kube-state-metrics component.
