### PR TITLE
feat: update node-exporter to 1.10.2 with chart v0.17.0

### DIFF
--- a/katalog/node-exporter/MAINTENANCE.md
+++ b/katalog/node-exporter/MAINTENANCE.md
@@ -4,14 +4,14 @@ To prepare a new release of this package:
 
 1. Get the current upstream release
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} node-exporter
-```
+   ```bash
+   export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   ../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} node-exporter
+   ```
 
-Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
 

--- a/katalog/node-exporter/clusterRole.yaml
+++ b/katalog/node-exporter/clusterRole.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.1
+    app.kubernetes.io/version: 1.10.2
   name: node-exporter
 rules:
 - apiGroups:

--- a/katalog/node-exporter/clusterRoleBinding.yaml
+++ b/katalog/node-exporter/clusterRoleBinding.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.1
+    app.kubernetes.io/version: 1.10.2
   name: node-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/katalog/node-exporter/daemonset.yaml
+++ b/katalog/node-exporter/daemonset.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.1
+    app.kubernetes.io/version: 1.10.2
   name: node-exporter
   namespace: monitoring
 spec:
@@ -27,7 +26,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: node-exporter
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 1.9.1
+        app.kubernetes.io/version: 1.10.2
     spec:
       automountServiceAccountToken: true
       containers:
@@ -43,7 +42,7 @@ spec:
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$
         - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
-        image: quay.io/prometheus/node-exporter:v1.9.1
+        image: quay.io/prometheus/node-exporter:v1.10.2
         name: node-exporter
         resources:
           limits:
@@ -78,7 +77,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100

--- a/katalog/node-exporter/prometheusRule.yaml
+++ b/katalog/node-exporter/prometheusRule.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.1
+    app.kubernetes.io/version: 1.10.2
     prometheus: k8s
     role: alert-rules
   name: node-exporter-rules
@@ -335,9 +334,9 @@ spec:
       annotations:
         description: Bonding interface {{ $labels.master }} on {{ $labels.instance }} is in degraded state due to one or more slave failures.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodebondingdegraded
-        summary: Bonding interface is degraded
+        summary: Bonding interface is degraded.
       expr: |
-        (node_bonding_slaves - node_bonding_active) != 0
+        (node_bonding_slaves{job="node-exporter"} - node_bonding_active{job="node-exporter"}) != 0
       for: 5m
       labels:
         severity: warning
@@ -408,3 +407,23 @@ spec:
           rate(node_network_transmit_drop_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_transmit_drop_excluding_lo:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_receive_bytes_total{job="node-exporter", device!~"lo|veth.+"}[5m])
+        )
+      record: instance:node_network_receive_bytes_physical:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_transmit_bytes_total{job="node-exporter", device!~"lo|veth.+"}[5m])
+        )
+      record: instance:node_network_transmit_bytes_physical:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_receive_drop_total{job="node-exporter", device!~"lo|veth.+"}[5m])
+        )
+      record: instance:node_network_receive_drop_physical:rate5m
+    - expr: |
+        sum without (device) (
+          rate(node_network_transmit_drop_total{job="node-exporter", device!~"lo|veth.+"}[5m])
+        )
+      record: instance:node_network_transmit_drop_physical:rate5m

--- a/katalog/node-exporter/service.yaml
+++ b/katalog/node-exporter/service.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.1
+    app.kubernetes.io/version: 1.10.2
   name: node-exporter
   namespace: monitoring
 spec:

--- a/katalog/node-exporter/serviceAccount.yaml
+++ b/katalog/node-exporter/serviceAccount.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
@@ -11,6 +10,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.1
+    app.kubernetes.io/version: 1.10.2
   name: node-exporter
   namespace: monitoring

--- a/katalog/node-exporter/serviceMonitor.yaml
+++ b/katalog/node-exporter/serviceMonitor.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.1
+    app.kubernetes.io/version: 1.10.2
   name: node-exporter
   namespace: monitoring
 spec:


### PR DESCRIPTION
### Summary 💡

Update node-exporter to 1.10.2 with chart v0.17.0.


### Description 📝

Update node-exporter to 1.10.2 with chart v0.17.0.

### Breaking Changes 💔

Handled.

#### node-exporter 1.9.1 → 1.10.2

| Version | Breaking Change | Action Taken |
|---------|----------------|--------------|
| 1.10.0 | `[CHANGE]` mdadm: Use sysfs for RAID metrics — reads from sysfs instead of `/proc/mdstat`, changing metric names/labels from `node_mdstat_*` to new sysfs-based metrics | Not applicable: the `mdadm` collector is not explicitly enabled in our DaemonSet args and defaults to disabled |
| 1.10.0 | `[CHANGE]` filesystem: Add erofs in default excluded fs — `erofs` added to default `--collector.filesystem.fs-types-exclude` list | Not applicable: we use `--collector.filesystem.mount-points-exclude` (not `fs-types-exclude`); no `erofs` mount points in typical Kubernetes nodes |
| 1.10.0 | `[CHANGE]` tcpstat: Use std lib `binary.NativeEndian` — may produce slightly different metric values on big-endian architectures | Not applicable: the `tcpstat` collector is not explicitly enabled in our DaemonSet args and defaults to disabled |

#### kube-rbac-proxy 0.19.1 → 0.21.0 no breaking changes

#### Additional PR changes (kube-prometheus v0.16.0 → v0.17.0 sync)

| Change | File | Action Taken |
|--------|------|--------------|
| Added `job="node-exporter"` label filter to `NodeBondingDegraded` alert expression | `prometheusRule.yaml` | Done in this PR: synced from upstream kube-prometheus v0.17.0 |
| Added 4 new recording rules for physical network metrics (`instance:node_network_receive_bytes_physical:rate5m`, `instance:node_network_transmit_bytes_physical:rate5m`, `instance:node_network_receive_drop_physical:rate5m`, `instance:node_network_transmit_drop_physical:rate5m`) filtering out `lo` and `veth.+` | `prometheusRule.yaml` | Done in this PR: synced from upstream kube-prometheus v0.17.0 |
| Removed redundant leading `---` YAML document separator from all files | All YAML files | Done in this PR: synced from upstream kube-prometheus v0.17.0 |


### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2736

I also tested updating the manifests from the old to the new one.

### Future work 🔧

Upgrade prometheus-adapter component.
