### PR TITLE
feat: update prometheus-adapter with helm chart 0-17.0 and fix container-image-sync references

### DIFF
--- a/katalog/alertmanager-operated/MAINTENANCE.md
+++ b/katalog/alertmanager-operated/MAINTENANCE.md
@@ -13,7 +13,7 @@ To prepare a new release of this package:
 
 2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
 

--- a/katalog/blackbox-exporter/MAINTENANCE.md
+++ b/katalog/blackbox-exporter/MAINTENANCE.md
@@ -13,6 +13,6 @@ To prepare a new release of this package:
 
 2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.

--- a/katalog/grafana/MAINTENANCE.md
+++ b/katalog/grafana/MAINTENANCE.md
@@ -15,7 +15,7 @@ To prepare a new release of this package:
 
 2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
 

--- a/katalog/kube-state-metrics/MAINTENANCE.md
+++ b/katalog/kube-state-metrics/MAINTENANCE.md
@@ -13,7 +13,7 @@ To prepare a new release of this package:
 
 2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
 

--- a/katalog/node-exporter/MAINTENANCE.md
+++ b/katalog/node-exporter/MAINTENANCE.md
@@ -13,6 +13,6 @@ To prepare a new release of this package:
 
 2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.

--- a/katalog/prometheus-adapter/MAINTENANCE.md
+++ b/katalog/prometheus-adapter/MAINTENANCE.md
@@ -18,7 +18,7 @@ To prepare a new release of this package:
 
 2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
 

--- a/katalog/prometheus-adapter/MAINTENANCE.md
+++ b/katalog/prometheus-adapter/MAINTENANCE.md
@@ -2,27 +2,43 @@
 
 To prepare a new release of this package:
 
-1. Get the current upstream release
+1. Run the upgrade script
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} prometheus-adapter
-```
+   ```bash
+   export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   ../../utils/pull-upstream.sh "${KUBE_PROMETHEUS_RELEASE}" prometheus-adapter
+   ```
 
-Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release. The script will:
+   - Pull upstream manifests from kube-prometheus
+    - Extract the adapter config from the Helm chart
+    - Generate `config.yaml` from the rendered Helm template
+   - Sync labels in `apiService-EnhancedHPAMetrics.yaml` with upstream
+   - Add license headers
 
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
 3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.
 
-5. Compare the `configMap.yaml` and `config.yaml` files, make sure the common part is up-to-date and keep the full metrics `rules` `externalRules` `resourceRules` enabled.
-
 ## Customizations
 
 We diverge from upstream in the following ways:
 
-1. We changed the config.yaml to a `configMap.yaml` file (step 5.) so we can patch it in the distribution easily when we need it.
-2. We add 2 additional API services via the apiService-EnhancedHPAMetrics.yaml file that are not included in upstream's manifests. See: https://github.com/sighupio/module-monitoring/issues/191
-3. We add the 2 additional API services to the ClusterRole via a patch, so the adapter can serve them.
+1. We use a `configMapGenerator` in `kustomization.yaml` to embed `config.yaml` as a ConfigMap, so we can patch it in the distribution easily when we need it.
+2. We add two additional API services (`v1beta1.custom.metrics.k8s.io` and `v1beta1.external.metrics.k8s.io`) via the `apiService-EnhancedHPAMetrics.yaml` file that are not included in upstream kube-prometheus manifests. See: https://github.com/sighupio/module-monitoring/issues/191
+3. We add the two additional API services to the ClusterRole via a patch in `kustomization.yaml`, so the adapter can serve them.
+4. We extract the adapter config from the Helm chart via `pull-upstream.sh` and write it to `config.yaml`, keeping the full `rules`, `externalRules`, and `resourceRules` enabled.
+5. We use `patchesJson6902` in `kustomization.yaml` to override the namespace of the `resource-metrics-auth-reader` RoleBinding to `kube-system`. We can't use regular `patches` because it runs before the namespace transformer, which would overwrite the change. See: https://github.com/kubernetes-sigs/kustomize/issues/5626
+
+## Generated Configuration
+
+The `config.yaml` file is **auto-generated** and must not be edited manually. It is produced by rendering the `prometheus-community/prometheus-adapter` Helm chart using the values defined in `values/prometheus-adapter.yml`.
+
+The value file contains:
+- **Custom rules** (`rules.custom`): metric discovery and query rules derived from the upstream kube-prometheus defaults, with a 1-minute rate window instead of the default 5 minutes.
+- **Resource rules** (`rules.resource`): CPU and memory queries for HPA, sourced from the upstream kube-prometheus `resourceRules`.
+- **External rules** (`rules.external`): queue-length and queue-size external metric rules from the prometheus-community Helm chart defaults.
+
+During an upgrade, the `pull-upstream.sh` script renders the Helm chart, extracts the generated config, and writes it to `config.yaml`. Any customization to the adapter behavior should be done in `values/prometheus-adapter.yml`.

--- a/katalog/prometheus-adapter/clusterRoleServerResources.yaml
+++ b/katalog/prometheus-adapter/clusterRoleServerResources.yaml
@@ -12,9 +12,11 @@ metadata:
     app.kubernetes.io/version: 0.12.0
   name: resource-metrics-server-resources
 rules:
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  - apiGroups:
+      - metrics.k8s.io
+      - custom.metrics.k8s.io
+      - external.metrics.k8s.io
+    resources:
+      - '*'
+    verbs:
+      - '*'

--- a/katalog/prometheus-adapter/config.yaml
+++ b/katalog/prometheus-adapter/config.yaml
@@ -145,3 +145,4 @@ resourceRules:
         pod:
           resource: pod
   window: 5m
+

--- a/katalog/prometheus-adapter/kustomization.yaml
+++ b/katalog/prometheus-adapter/kustomization.yaml
@@ -46,19 +46,6 @@ patches:
                     memory: 3072Mi
                   limits:
                     memory: 4096Mi
-  # Needed for the Horizontal Pod Autoscaler to work with custom metrics
-  - target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: ClusterRole
-      name: resource-metrics-server-resources
-    patch: |-
-      - op: add
-        path: /rules/0/apiGroups/-
-        value: "custom.metrics.k8s.io"
-      - op: add
-        path: /rules/0/apiGroups/-
-        value: "external.metrics.k8s.io"
 
 # We can't do a normal patch here because we need to change the namespace of an existing object
 # and `patches` does not support that, the JsonPatch gets applied before the namespace transformer.

--- a/katalog/prometheus-operated/MAINTENANCE.md
+++ b/katalog/prometheus-operated/MAINTENANCE.md
@@ -20,7 +20,7 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
 4. Move `KubeClientCertificateExpiration`, `KubeSchedulerDown` and `KubeControllerManagerDown` alerts from `kubernetes-monitoring-rules.yml` to `configs/kubeadm/rules.yml`.
 
-5. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+5. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 6. Update the Prometheus Agent manifests in the distribution with the new image:
 

--- a/katalog/prometheus-operator/MAINTENANCE.md
+++ b/katalog/prometheus-operator/MAINTENANCE.md
@@ -13,6 +13,6 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
 2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
 
-3. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+3. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 4. Update the `kustomization.yaml` file with the new image.

--- a/katalog/x509-exporter/MAINTENANCE.md
+++ b/katalog/x509-exporter/MAINTENANCE.md
@@ -27,7 +27,7 @@ NOTE: The labels added by Helm have been removed and changed to `app: x509-certi
 
 NOTE2: Grafana dashboard is taken from: https://github.com/enix/x509-certificate-exporter/blob/v3.19.1/deploy/charts/x509-certificate-exporter/grafana-dashboards/x509-certificate-exporter.json or take it from the generated configmap.
 
-1. Sync the new image to our registry in the [`monitoring` images.yaml file fury-distribution-container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/monitoring/images.yml).
+1. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
 
 2. Update each `kustomization.yaml` file with the new image.
 

--- a/utils/pull-upstream.sh
+++ b/utils/pull-upstream.sh
@@ -159,24 +159,21 @@ case "${FURY_MODULE}" in
     ;;
   "prometheus-adapter")
     populate_package "prometheusAdapter"
+    rm configMap.yaml
     helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm repo update
     PROMETHEUS_ADAPTER_RELEASE=$(yq '.metadata.labels."app.kubernetes.io/version"' < apiService.yaml )
-    yq '.metadata.labels' < apiService.yaml > "${WORK_DIR}/labels.yml"
-    KUBE_PROMETHEUS_ADAPTER_RELEASE=$(helm search repo prometheus-adapter -l -o json | jq -r --arg PROMETHEUS_ADAPTER_RELEASE "${PROMETHEUS_ADAPTER_RELEASE}" '.[] | select(.app_version == ("v"+$PROMETHEUS_ADAPTER_RELEASE)) | .version')
-    cd "${WORK_DIR}"
+    KUBE_PROMETHEUS_ADAPTER_RELEASE=$(helm search repo prometheus-community/prometheus-adapter -l -o json | jq -r --arg PROMETHEUS_ADAPTER_RELEASE "${PROMETHEUS_ADAPTER_RELEASE}" '[.[] | select(.app_version == ("v"+$PROMETHEUS_ADAPTER_RELEASE)) | .version] | first')
     helm template \
       --release-name prometheus-adapter \
       --namespace monitoring \
       -f "${VALUES_PATH}/prometheus-adapter.yml" \
       --api-versions apiregistration.k8s.io/v1 \
       --version "${KUBE_PROMETHEUS_ADAPTER_RELEASE}" \
-      prometheus-community/prometheus-adapter | yq --split-exp '.kind + "-" + .metadata.name'
-    cd -
-    grep -v '#' < "${WORK_DIR}/APIService-v1beta1.custom.metrics.k8s.io"  | yq "del(.metadata.labels) | .metadata.labels = (load(\"${WORK_DIR}/labels.yml\"))" >> "${KATALOG_PATH}/prometheus-adapter/apiService.yaml"
-    grep -v '#' < "${WORK_DIR}/APIService-v1beta1.external.metrics.k8s.io" | yq "del(.metadata.labels) | .metadata.labels = (load(\"${WORK_DIR}/labels.yml\"))" >> "${KATALOG_PATH}/prometheus-adapter/apiService.yaml"
-    yq -i ".data = (load(\"${WORK_DIR}/ConfigMap-prometheus-adapter.yml\") | .data)" configMap.yaml
+      prometheus-community/prometheus-adapter | \
+      yq 'select(.kind == "ConfigMap" and .metadata.name == "prometheus-adapter") | .data."config.yaml"' > config.yaml
+    yq -i '.metadata.labels = (load("apiService.yaml") | .metadata.labels)' apiService-EnhancedHPAMetrics.yaml
     yq -i '.rules[0].apiGroups = ["metrics.k8s.io", "custom.metrics.k8s.io", "external.metrics.k8s.io"]' clusterRoleServerResources.yaml
-    # shellcheck disable=SC2086
     yq -i ".spec.template.metadata.annotations.\"checksum.config/md5\" = \"$(md5 -q ${VALUES_PATH}/prometheus-adapter.yml)\"" deployment.yaml
     ;;
   "prometheus-operated")


### PR DESCRIPTION
### Summary 💡

Update prometheus-adapter with helm chart 0.17.0 and fix container-image-sync references.

### Description 📝

- Update prometheus-adapter with helm chart 0.17.0 (no changes).
- Fix container-image-sync references.
- Fixed pull upstream script that did not handle multiple chart versions.
- Removed patch resource-metrics-server-resources that is already done by pull upstream script.


### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2772

I also tested updating the manifests from the old to the new one.

### Future work 🔧

Update prometheus-operated component.
