### PR TITLE
feat: update prometheus-operated to 3.10.0 with helm chart 0.17.0

### DIFF
--- a/katalog/configs/kubeadm/rules.yml
+++ b/katalog/configs/kubeadm/rules.yml
@@ -12,243 +12,243 @@ metadata:
   namespace: monitoring
 spec:
   groups:
-  - name: kubernetes-absent-kubeadm
-    rules:
-    - alert: KubeControllerManagerDown
-      annotations:
-        description: KubeControllerManager has disappeared from Prometheus target discovery.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontrollermanagerdown
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-controller-manager"} == 1)
-      for: 15m
-      labels:
-        severity: critical
-    - alert: KubeSchedulerDown
-      annotations:
-        description: KubeScheduler has disappeared from Prometheus target discovery.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeschedulerdown
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-scheduler"} == 1)
-      for: 15m
-      labels:
-        severity: critical
-    - alert: KubeClientCertificateExpiration
-      annotations:
-        description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 7.0 days on cluster {{ $labels.cluster }}.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclientcertificateexpiration
-        summary: Client certificate is about to expire.
-      expr: |
-        histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
-        and
-        on(job, cluster, instance) apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
-      for: 5m
-      labels:
-        severity: warning
-    - alert: KubeClientCertificateExpiration
-      annotations:
-        description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 24.0 hours on cluster {{ $labels.cluster }}.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclientcertificateexpiration
-        summary: Client certificate is about to expire.
-      expr: |
-        histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
-        and
-        on(job, cluster, instance) apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
-      for: 5m
-      labels:
-        severity: critical
-  - name: etcd3
-    rules:
-    - alert: EtcdInsufficientMembers
-      annotations:
-        description: 'If one more etcd member goes down the cluster will be
+    - name: kubernetes-absent-kubeadm
+      rules:
+        - alert: KubeControllerManagerDown
+          annotations:
+            description: KubeControllerManager has disappeared from Prometheus target discovery.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontrollermanagerdown
+            summary: Target disappeared from Prometheus target discovery.
+          expr: |
+            absent(up{job="kube-controller-manager"})
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeSchedulerDown
+          annotations:
+            description: KubeScheduler has disappeared from Prometheus target discovery.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeschedulerdown
+            summary: Target disappeared from Prometheus target discovery.
+          expr: |
+            absent(up{job="kube-scheduler"})
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeClientCertificateExpiration
+          annotations:
+            description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 7.0 days on cluster {{ $labels.cluster }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclientcertificateexpiration
+            summary: Client certificate is about to expire.
+          expr: |
+            histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
+            and
+            on(job, cluster, instance) apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeClientCertificateExpiration
+          annotations:
+            description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 24.0 hours on cluster {{ $labels.cluster }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclientcertificateexpiration
+            summary: Client certificate is about to expire.
+          expr: |
+            histogram_quantile(0.01, sum without (namespace, service, endpoint) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
+            and
+            on(job, cluster, instance) apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
+          for: 5m
+          labels:
+            severity: critical
+    - name: etcd3
+      rules:
+        - alert: EtcdInsufficientMembers
+          annotations:
+            description: 'If one more etcd member goes down the cluster will be
           unavailable.'
-        doc: "This alert fires if less than half of Etcd cluster members were
+            doc: "This alert fires if less than half of Etcd cluster members were
           online in the last 3 minutes."
-      expr: |
-        count(up{job="etcd-metrics"} == 0) > (count(up{job="etcd-metrics"}) / 2 - 1)
-      for: 3m
-      labels:
-        severity: critical
-    - alert: EtcdNoLeader
-      annotations:
-        description: 'Etcd member {{ $labels.instance }} has no leader.'
-        doc: "This alert fires if the Etcd cluster had no leader in the last
+          expr: |
+            count(up{job="etcd-metrics"} == 0) > (count(up{job="etcd-metrics"}) / 2 - 1)
+          for: 3m
+          labels:
+            severity: critical
+        - alert: EtcdNoLeader
+          annotations:
+            description: 'Etcd member {{ $labels.instance }} has no leader.'
+            doc: "This alert fires if the Etcd cluster had no leader in the last
           minute."
-      expr: |
-        etcd_server_has_leader{job="etcd-metrics"} == 0
-      for: 1m
-      labels:
-        severity: critical
-    - alert: EtcdHighNumberOfLeaderChanges
-      annotations:
-        description: 'Etcd instance {{ $labels.instance }} has seen {{ $value }}
+          expr: |
+            etcd_server_has_leader{job="etcd-metrics"} == 0
+          for: 1m
+          labels:
+            severity: critical
+        - alert: EtcdHighNumberOfLeaderChanges
+          annotations:
+            description: 'Etcd instance {{ $labels.instance }} has seen {{ $value }}
           leader changes within the last hour.'
-        doc: "This alert fires if the Etcd cluster changed leader more than 3
+            doc: "This alert fires if the Etcd cluster changed leader more than 3
           times in the last hour."
-      expr: |
-        increase(etcd_server_leader_changes_seen_total{job="etcd-metrics"}[1h]) > 3
-      labels:
-        severity: warning
-    # - alert: EtcdHighNumberOfFailedGRPCRequests
-    #   annotations:
-    #     description: '{{ $value | printf "%.2f" }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
-    #   expr: |
-    #     100 * (sum(rate(grpc_server_handled_total{grpc_code!="OK",job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)
-    #       /
-    #     sum(rate(grpc_server_handled_total{job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)) > 1
-    #   for: 10m
-    #   labels:
-    #     severity: warning
-    # - alert: EtcdHighNumberOfFailedGRPCRequests
-    #   annotations:
-    #     description: '{{ $value | printf "%.2f" }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
-    #   expr: |
-    #     100 * (sum(rate(grpc_server_handled_total{grpc_code!="OK",job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)
-    #       /
-    #     sum(rate(grpc_server_handled_total{job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)) > 5
-    #   for: 5m
-    #   labels:
-    #     severity: critical
-    # - alert: EtcdGRPCRequestsSlow
-    #   annotations:
-    #     description: on etcd instance {{ $labels.instance }} gRPC requests to {{ $labels.grpc_method
-    #       }} are slow
-    #   expr: |
-    #     histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd-metrics",grpc_type="unary"}[5m])) by (grpc_service, grpc_method, le)) > 0.15
-    #   for: 10m
-    #   labels:
-    #     severity: critical
-    # - alert: EtcdMemberCommunicationSlow
-    #   annotations:
-    #     description: etcd instance {{ $labels.instance }} member communication with {{ $labels.To }} is slow
-    #   expr: |
-    #     histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m])) > 0.15
-    #   for: 10m
-    #   labels:
-    #     severity: warning
-    - alert: EtcdHighNumberOfFailedProposals
-      annotations:
-        description: 'Etcd instance {{ $labels.instance }} has seen {{ $value }}
+          expr: |
+            increase(etcd_server_leader_changes_seen_total{job="etcd-metrics"}[1h]) > 3
+          labels:
+            severity: warning
+        # - alert: EtcdHighNumberOfFailedGRPCRequests
+        #   annotations:
+        #     description: '{{ $value | printf "%.2f" }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
+        #   expr: |
+        #     100 * (sum(rate(grpc_server_handled_total{grpc_code!="OK",job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)
+        #       /
+        #     sum(rate(grpc_server_handled_total{job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)) > 1
+        #   for: 10m
+        #   labels:
+        #     severity: warning
+        # - alert: EtcdHighNumberOfFailedGRPCRequests
+        #   annotations:
+        #     description: '{{ $value | printf "%.2f" }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
+        #   expr: |
+        #     100 * (sum(rate(grpc_server_handled_total{grpc_code!="OK",job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)
+        #       /
+        #     sum(rate(grpc_server_handled_total{job="etcd-metrics"}[5m])) by (grpc_service, grpc_method, instance)) > 5
+        #   for: 5m
+        #   labels:
+        #     severity: critical
+        # - alert: EtcdGRPCRequestsSlow
+        #   annotations:
+        #     description: on etcd instance {{ $labels.instance }} gRPC requests to {{ $labels.grpc_method
+        #       }} are slow
+        #   expr: |
+        #     histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd-metrics",grpc_type="unary"}[5m])) by (grpc_service, grpc_method, le)) > 0.15
+        #   for: 10m
+        #   labels:
+        #     severity: critical
+        # - alert: EtcdMemberCommunicationSlow
+        #   annotations:
+        #     description: etcd instance {{ $labels.instance }} member communication with {{ $labels.To }} is slow
+        #   expr: |
+        #     histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m])) > 0.15
+        #   for: 10m
+        #   labels:
+        #     severity: warning
+        - alert: EtcdHighNumberOfFailedProposals
+          annotations:
+            description: 'Etcd instance {{ $labels.instance }} has seen {{ $value }}
           proposal failures within the last hour.'
-        doc: "This alert fires if there were more than 5 proposal failure in the
+            doc: "This alert fires if there were more than 5 proposal failure in the
           last hour."
-      expr: |
-        increase(etcd_server_proposals_failed_total{job="etcd-metrics"}[1h]) > 5
-      labels:
-        severity: warning
-    - alert: EtcdHighFsyncDurations
-      annotations:
-        description: 'Etcd instance {{ $labels.instance }} WAL fsync latency too
+          expr: |
+            increase(etcd_server_proposals_failed_total{job="etcd-metrics"}[1h]) > 5
+          labels:
+            severity: warning
+        - alert: EtcdHighFsyncDurations
+          annotations:
+            description: 'Etcd instance {{ $labels.instance }} WAL fsync latency too
           high, current latency is {{ $value | printf "%.2f" }}.'
-        doc: "This alert fires if the WAL fsync 99th percentile latency was
+            doc: "This alert fires if the WAL fsync 99th percentile latency was
           higher than 0.5s in the last 10 minutes."
-      expr: |
-        histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
-      for: 10m
-      labels:
-        severity: warning
-    - alert: EtcdHighCommitDurations
-      annotations:
-        description: 'Etcd instance {{ $labels.instance }} commit latency too high,
+          expr: |
+            histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+        - alert: EtcdHighCommitDurations
+          annotations:
+            description: 'Etcd instance {{ $labels.instance }} commit latency too high,
           current latency is {{ $value | printf "%.2f" }}.'
-        doc: "This alert fires if the backend commit 99th percentile latency was
+            doc: "This alert fires if the backend commit 99th percentile latency was
           higher than 0.25s in the last 10 minutes."
-      expr: |
-        histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.25
-      for: 10m
-      labels:
-        severity: warning
-  - name: coredns.rules
-    rules:
-      - alert: CoreDNSPanic
-        annotations:
-          description: 'CoreDNS instance {{ $labels.instance }} panic count
+          expr: |
+            histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.25
+          for: 10m
+          labels:
+            severity: warning
+    - name: coredns.rules
+      rules:
+        - alert: CoreDNSPanic
+          annotations:
+            description: 'CoreDNS instance {{ $labels.instance }} panic count
             increased by {{ $value }}.'
-          doc: "This alert fires if CoreDNS total panic count increased by at
+            doc: "This alert fires if CoreDNS total panic count increased by at
             least 1 in the last 10 minutes."
-        expr: |
-          increase(coredns_panic_count_total[10m]) > 0
-        labels:
-          severity: critical
-      - alert: CoreDNSRequestsLatency
-        annotations:
-          description: 'CoreDNS instance {{ $labels.instance }} requests latency too
+          expr: |
+            increase(coredns_panic_count_total[10m]) > 0
+          labels:
+            severity: critical
+        - alert: CoreDNSRequestsLatency
+          annotations:
+            description: 'CoreDNS instance {{ $labels.instance }} requests latency too
             high, current latency is {{ $value | printf "%.2f" }}.'
-          doc: "This alert fires if CoreDNS 99th percentile requests latency was
+            doc: "This alert fires if CoreDNS 99th percentile requests latency was
             higher than 100ms in the last 10 minutes."
-        expr: |
-          histogram_quantile(0.99, sum by (le,instance,pod) (rate(coredns_dns_request_duration_seconds_bucket[2m]))) > 0.1
-        for: 10m
-        labels:
-          severity: warning
-      - alert: CoreDNSHealthRequestsLatency
-        annotations:
-          description: 'CoreDNS instance {{ $labels.instance }} health requests
+          expr: |
+            histogram_quantile(0.99, sum by (le,instance,pod) (rate(coredns_dns_request_duration_seconds_bucket[2m]))) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+        - alert: CoreDNSHealthRequestsLatency
+          annotations:
+            description: 'CoreDNS instance {{ $labels.instance }} health requests
             latency too high, current latency is {{ $value | printf "%.2f" }}.'
-          doc: "This alert fires if CoreDNS 99th percentile health requests
+            doc: "This alert fires if CoreDNS 99th percentile health requests
             latency was higher than 10ms in the last 10 minutes."
-        expr: |
-          histogram_quantile(0.99, sum by (le,instance,pod) (rate(coredns_health_request_duration_seconds_bucket[2m]))) > 0.01
-        for: 10m
-        labels:
-          severity: warning
-      - alert: CoreDNSForwardRequestsLatency
-        annotations:
-          description: 'CoreDNS instance {{ $labels.instance }} forward requests
+          expr: |
+            histogram_quantile(0.99, sum by (le,instance,pod) (rate(coredns_health_request_duration_seconds_bucket[2m]))) > 0.01
+          for: 10m
+          labels:
+            severity: warning
+        - alert: CoreDNSForwardRequestsLatency
+          annotations:
+            description: 'CoreDNS instance {{ $labels.instance }} forward requests
             latency too high, current latency is {{ $value | printf "%.2f" }}.'
-          doc: "This alert fires if CoreDNS 99th percentile forward requests
+            doc: "This alert fires if CoreDNS 99th percentile forward requests
             latency was higher than 500ms in the last 10 minutes."
-        expr: |
-          histogram_quantile(0.99, sum by (le,instance,pod,proto) (rate(coredns_forward_request_duration_seconds_bucket[2m]))) > 0.5
-        for: 10m
-        labels:
-          severity: warning
-  - name: kube-scheduler.rules
-    rules:
-    - expr: |
-        histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.99"
-      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.99"
-      record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.99"
-      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.9"
-      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.9"
-      record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.9"
-      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.5"
-      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.5"
-      record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
-    - expr: |
-        histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
-      labels:
-        quantile: "0.5"
-      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+          expr: |
+            histogram_quantile(0.99, sum by (le,instance,pod,proto) (rate(coredns_forward_request_duration_seconds_bucket[2m]))) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+    - name: kube-scheduler.rules
+      rules:
+        - expr: |
+            histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.99"
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.99"
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.99"
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.9"
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.9"
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.9"
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.5"
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.5"
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.5"
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile

--- a/katalog/prometheus-operated/MAINTENANCE.md
+++ b/katalog/prometheus-operated/MAINTENANCE.md
@@ -4,17 +4,17 @@ To prepare a new release of this package:
 
 1. Get the current upstream release and update local files:
 
-> [!IMPORTANT]
-> Run the following command from the `katalog` folder.
+   > [!IMPORTANT]
+   > Run the following command from the `katalog` folder.
 
-```bash
-export KUBE_PROMETHEUS_RELEASE=v0.16.0
-../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} prometheus-operated
-```
+   ```bash
+   export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   ../utils/pull-upstream.sh ${KUBE_PROMETHEUS_RELEASE} prometheus-operated
+   ```
 
-Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
-2. Check the differences introduced by pulling the upstream release and add the needed patches in `kustomization.yaml`
+2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
 3. Remove from `kubernetes-monitoring-rules.yml` the `CPUThrottlingHigh` alert.
 
@@ -24,11 +24,11 @@ Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
 
 6. Update the Prometheus Agent manifests in the distribution with the new image:
 
-https://github.com/sighupio/distribution/blob/91b1edbd242bd453769c0ad69e6e82477b88922c/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl#L12
+   https://github.com/sighupio/distribution/blob/91b1edbd242bd453769c0ad69e6e82477b88922c/templates/distribution/manifests/monitoring/resources/prometheus-agent/prometheus-agent.yaml.tpl#L12
 
 7. Make sure that all the files have the license headers:
 
-```bash
-mise run add-license
-```
+   ```bash
+   mise run add-license
+   ```
 

--- a/katalog/prometheus-operated/clusterRole.yaml
+++ b/katalog/prometheus-operated/clusterRole.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: prometheus-k8s
 rules:
 - apiGroups:

--- a/katalog/prometheus-operated/clusterRoleBinding.yaml
+++ b/katalog/prometheus-operated/clusterRoleBinding.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/katalog/prometheus-operated/kube-prometheus-rules.yml
+++ b/katalog/prometheus-operated/kube-prometheus-rules.yml
@@ -50,7 +50,7 @@ spec:
           This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/infoinhibitor
         summary: Info-level alert inhibition.
-      expr: ALERTS{severity = "info"} == 1 unless on(namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
+      expr: group by (namespace) (ALERTS{severity = "info"} == 1) unless on (namespace) group by (namespace) (ALERTS{alertname != "InfoInhibitor", alertstate = "firing", severity =~ "warning|critical"} == 1)
       labels:
         severity: none
   - name: node-network

--- a/katalog/prometheus-operated/kubernetes-monitoring-rules.yml
+++ b/katalog/prometheus-operated/kubernetes-monitoring-rules.yml
@@ -33,9 +33,9 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready
         summary: Pod has been in a non-ready state for more than 15 minutes.
       expr: |
-        sum by (namespace, pod, cluster) (
-          max by(namespace, pod, cluster) (
-            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+        sum by (namespace, pod, job, cluster) (
+          max by(namespace, pod, job, cluster) (
+            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
           )
@@ -253,9 +253,16 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
         summary: HPA is running at max replicas
       expr: |
-        kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
-          ==
-        kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+        (
+          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+            ==
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+        )
+        and on(namespace, horizontalpodautoscaler) (
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+            !=
+          kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics"}
+        )
       for: 15m
       labels:
         severity: warning
@@ -380,10 +387,16 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaalmostfull
         summary: Namespace quota is going to be full.
       expr: |
-        kube_resourcequota{job="kube-state-metrics", type="used"}
-          / ignoring(instance, job, type)
-        (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
-          > 0.9 < 1
+        max without (instance, job, type) (
+          kube_resourcequota{job="kube-state-metrics", type="used"}
+        )
+        / on (cluster, namespace, resource, resourcequota) group_left()
+        (
+          max without (instance, job, type) (
+            kube_resourcequota{job="kube-state-metrics", type="hard"}
+          ) > 0
+        )
+        > 0.9 < 1
       for: 15m
       labels:
         severity: info
@@ -393,10 +406,16 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotafullyused
         summary: Namespace quota is fully used.
       expr: |
-        kube_resourcequota{job="kube-state-metrics", type="used"}
-          / ignoring(instance, job, type)
-        (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
-          == 1
+        max without (instance, job, type) (
+          kube_resourcequota{job="kube-state-metrics", type="used"}
+        )
+        / on (cluster, namespace, resource, resourcequota) group_left()
+        (
+          max without (instance, job, type) (
+            kube_resourcequota{job="kube-state-metrics", type="hard"}
+          ) > 0
+        )
+        == 1
       for: 15m
       labels:
         severity: info
@@ -406,10 +425,15 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaexceeded
         summary: Namespace quota has exceeded the limits.
       expr: |
-        kube_resourcequota{job="kube-state-metrics", type="used"}
-          / ignoring(instance, job, type)
-        (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
-          > 1
+        max without (instance, job, type) (
+          kube_resourcequota{job="kube-state-metrics", type="used"}
+        )
+        / on (cluster, namespace, resource, resourcequota) group_left()
+        (
+          max without (instance, job, type) (
+            kube_resourcequota{job="kube-state-metrics", type="hard"}
+          ) > 0
+        ) > 1
       for: 15m
       labels:
         severity: warning
@@ -620,7 +644,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapidown
         summary: Target disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="apiserver"} == 1)
+        absent(up{job="apiserver"})
       for: 15m
       labels:
         severity: critical
@@ -808,11 +832,13 @@ spec:
         severity: warning
     - alert: KubeletDown
       annotations:
-        description: Kubelet has disappeared from Prometheus target discovery.
+        description: Kubelet has disappeared from Prometheus target discovery on cluster {{ $labels.cluster }}.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletdown
         summary: Target disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+        count by (cluster) (kube_node_info{job="kube-state-metrics"})
+        unless on (cluster)
+        count by (cluster) (up{job="kubelet", metrics_path="/metrics"} == 1)
       for: 15m
       labels:
         severity: critical
@@ -1505,50 +1531,50 @@ spec:
   - name: kube-scheduler.rules
     rules:
     - expr: |
-        histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        histogram_quantile(0.99, sum(rate(scheduler_scheduling_attempt_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.99"
-      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      record: cluster_quantile:scheduler_scheduling_attempt_duration_seconds:histogram_quantile
     - expr: |
         histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.99"
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
     - expr: |
-        histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        histogram_quantile(0.99, sum(rate(scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.99"
-      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+      record: cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile
     - expr: |
-        histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        histogram_quantile(0.9, sum(rate(scheduler_scheduling_attempt_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.9"
-      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      record: cluster_quantile:scheduler_scheduling_attempt_duration_seconds:histogram_quantile
     - expr: |
         histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.9"
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
     - expr: |
-        histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        histogram_quantile(0.9, sum(rate(scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.9"
-      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+      record: cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile
     - expr: |
-        histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        histogram_quantile(0.5, sum(rate(scheduler_scheduling_attempt_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.5"
-      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      record: cluster_quantile:scheduler_scheduling_attempt_duration_seconds:histogram_quantile
     - expr: |
         histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.5"
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
     - expr: |
-        histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        histogram_quantile(0.5, sum(rate(scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: "0.5"
-      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+      record: cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile
   - name: node.rules
     rules:
     - expr: |

--- a/katalog/prometheus-operated/kustomization.yaml
+++ b/katalog/prometheus-operated/kustomization.yaml
@@ -31,7 +31,7 @@ patches:
         name: k8s
         namespace: monitoring
       spec:
-        image: registry.sighup.io/fury/prometheus/prometheus:v3.5.0
+        image: registry.sighup.io/fury/prometheus/prometheus:v3.10.0
         replicas: 1
         resources:
           requests:

--- a/katalog/prometheus-operated/prometheus.yaml
+++ b/katalog/prometheus-operated/prometheus.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: k8s
   namespace: monitoring
 spec:
@@ -22,7 +22,7 @@ spec:
       port: web
   enableFeatures: []
   externalLabels: {}
-  image: quay.io/prometheus/prometheus:v3.5.0
+  image: quay.io/prometheus/prometheus:v3.10.0
   nodeSelector:
     kubernetes.io/os: linux
   podMetadata:
@@ -31,7 +31,7 @@ spec:
       app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 3.5.0
+      app.kubernetes.io/version: 3.10.0
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   probeNamespaceSelector: {}
@@ -49,6 +49,7 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
   serviceAccountName: prometheus-k8s
+  serviceDiscoveryRole: EndpointSlice
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
-  version: 3.5.0
+  version: 3.10.0

--- a/katalog/prometheus-operated/prometheusRule.yaml
+++ b/katalog/prometheus-operated/prometheusRule.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
     prometheus: k8s
     role: alert-rules
   name: prometheus-k8s-prometheus-rules
@@ -182,8 +182,8 @@ spec:
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
         (
-          max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job="prometheus-k8s",namespace="monitoring"}[5m])
-        - ignoring(remote_name, url) group_right
+          max_over_time(prometheus_remote_storage_queue_highest_timestamp_seconds{job="prometheus-k8s",namespace="monitoring"}[5m])
+        -
           max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-k8s",namespace="monitoring"}[5m])
         )
         > 120

--- a/katalog/prometheus-operated/roleBindingConfig.yaml
+++ b/katalog/prometheus-operated/roleBindingConfig.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: prometheus-k8s-config
   namespace: monitoring
 roleRef:

--- a/katalog/prometheus-operated/roleConfig.yaml
+++ b/katalog/prometheus-operated/roleConfig.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: prometheus-k8s-config
   namespace: monitoring
 rules:

--- a/katalog/prometheus-operated/service.yaml
+++ b/katalog/prometheus-operated/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: prometheus-k8s
   namespace: monitoring
 spec:

--- a/katalog/prometheus-operated/serviceAccount.yaml
+++ b/katalog/prometheus-operated/serviceAccount.yaml
@@ -11,6 +11,6 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: prometheus-k8s
   namespace: monitoring

--- a/katalog/prometheus-operated/serviceMonitor.yaml
+++ b/katalog/prometheus-operated/serviceMonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 3.5.0
+    app.kubernetes.io/version: 3.10.0
   name: prometheus-k8s
   namespace: monitoring
 spec:

--- a/utils/pull-upstream.sh
+++ b/utils/pull-upstream.sh
@@ -173,7 +173,7 @@ case "${FURY_MODULE}" in
       prometheus-community/prometheus-adapter | \
       yq 'select(.kind == "ConfigMap" and .metadata.name == "prometheus-adapter") | .data."config.yaml"' > config.yaml
     yq -i '.metadata.labels = (load("apiService.yaml") | .metadata.labels)' apiService-EnhancedHPAMetrics.yaml
-    yq -i '.rules[0].apiGroups = ["metrics.k8s.io", "custom.metrics.k8s.io", "external.metrics.k8s.io"]' clusterRoleServerResources.yaml
+    yq -i '.rules[0].apiGroups += ["custom.metrics.k8s.io", "external.metrics.k8s.io"]' clusterRoleServerResources.yaml
     yq -i ".spec.template.metadata.annotations.\"checksum.config/md5\" = \"$(md5 -q ${VALUES_PATH}/prometheus-adapter.yml)\"" deployment.yaml
     ;;
   "prometheus-operated")


### PR DESCRIPTION
### Summary 💡

Update prometheus-operated to 3.10.0 with helm chart 0.17.0

### Description 📝

Update prometheus-operated to 3.10.0 with helm chart 0.17.0

### Breaking Changes 💔

Handled.
| Version | Breaking Change | Status |
|---------|----------------|--------|
| 3.7.0 | Remote-write metrics deprecated (`prometheus_remote_storage_samples_in_total`, `prometheus_remote_storage_histograms_in_total`, `prometheus_remote_storage_exemplars_in_total`, `prometheus_remote_storage_highest_timestamp_in_seconds`) | **AFFECTED - FIXED** |
| 3.8.0 | Remote Write 2.0: "created timestamp" (CT) renamed to "start timestamp" (ST) | NOT AFFECTED |
| 3.8.0 | Native Histogram: Custom bounds with NaN threshold now rejected | NOT AFFECTED |
| 3.9.0 | Native Histograms: `native-histogram` feature flag is now a no-op, use `scrape_native_histograms` instead | NOT AFFECTED |
| 3.9.0 | API TSDB: Maximum limit of 10,000 sets of statistics on status endpoint | NOT AFFECTED |
| 3.10.0 | UI: Alert annotations hidden by default | NOT AFFECTED |
| 3.10.0 | Alerting: `prometheus_notifications_*` metrics now have `alertmanager` dimension (`dropped_total`, `queue_length`, `queue_capacity` only; `errors_total` and `sent_total` already had it) | NOT AFFECTED |


### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2752

I also tested updating the manifests from the old to the new one.

### Future work 🔧

Update prometheus-operator component.