### PR TITLE
feat: enable drilldown dashboard

### DIFF
--- a/katalog/grafana/MAINTENANCE.md
+++ b/katalog/grafana/MAINTENANCE.md
@@ -6,12 +6,14 @@ To prepare a new release of this package:
 
    ```bash
    export KUBE_PROMETHEUS_RELEASE=v0.17.0
+   export K8S_SIDECAR_VERSION=2.7.3
+   export DRILLDOWN_VERSION=2.0.4
    ./upgrade.sh
    ```
    
-   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release.
+   Replace `KUBE_PROMETHEUS_RELEASE` with the current upstream release, `K8S_SIDECAR_VERSION` with the desired k8s-sidecar version, and `DRILLDOWN_VERSION` with the desired Grafana Logs Drilldown plugin version.
    
-   The script will pull the upstream release and automatically remove Windows and AIX dashboards from `deployment.yaml`.
+   The script will pull the upstream release, automatically remove Windows and AIX dashboards from `deployment.yaml`, update the k8s-sidecar image, and update the Drilldown plugin URL in the environment patch.
 
 2. Check the differences introduced by pulling the upstream release and add the necessary patches in `kustomization.yaml`
 
@@ -28,4 +30,6 @@ To prepare a new release of this package:
 - Added custom grafana dashboard (`fury-cluster-overview.json`), which shows an overview of the status of the resources present in the cluster. This is done via a kustomize patch.
 - Windows and AIX dashboards are removed automatically by the `upgrade.sh` script (JSON files and volume mounts).
 - Added default Kubernetes values for the readiness probe and introduced a liveness probe. The readiness probe defaults allow parameter customization, while the liveness probe was added to enable a more lenient approach to health checks and to recover from application hangs or failures. Both changes are applied using a Kustomize patch.
+- Added Grafana Logs Drilldown plugin (`grafana-lokiexplore-app`) via `GF_INSTALL_PLUGINS` environment variable. The plugin version is managed by the `DRILLDOWN_VERSION` env var in `upgrade.sh`.
+- Enabled feature toggles `exploreMetricsRelatedLogs` and `exploreLogsShardSplitting` in `grafana.ini` for metrics-to-logs correlation and query streaming.
 

--- a/katalog/grafana/kustomization.yaml
+++ b/katalog/grafana/kustomization.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring

--- a/katalog/grafana/patches/grafana-env.yaml
+++ b/katalog/grafana/patches/grafana-env.yaml
@@ -23,3 +23,5 @@ spec:
               value: "true"
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
               value: "Admin"
+            - name: GF_INSTALL_PLUGINS
+              value: "https://storage.googleapis.com/integration-artifacts/grafana-lokiexplore-app/release/2.0.4/any/grafana-lokiexplore-app-2.0.4.zip;grafana-lokiexplore-app"

--- a/katalog/grafana/patches/grafana-volumes.yaml
+++ b/katalog/grafana/patches/grafana-volumes.yaml
@@ -30,6 +30,9 @@ spec:
             - mountPath: /tmp
               name: tmp-plugins
               readOnly: false
+            - mountPath: /var/lib/grafana-plugins
+              name: grafana-plugins
+              readOnly: false
             - $patch: replace
       volumes:
         - name: grafana-config
@@ -46,6 +49,9 @@ spec:
           emptyDir:
             medium: Memory
         - name: tmp-plugins
+          emptyDir:
+            medium: Memory
+        - name: grafana-plugins
           emptyDir:
             medium: Memory
         - $patch: replace

--- a/katalog/grafana/upgrade.sh
+++ b/katalog/grafana/upgrade.sh
@@ -6,9 +6,22 @@
 set -euo pipefail
 
 if [ -z "${KUBE_PROMETHEUS_RELEASE:-}" ]; then
-  echo "Usage: KUBE_PROMETHEUS_RELEASE=v0.17.0 ./upgrade.sh"
+  echo "Usage: KUBE_PROMETHEUS_RELEASE=v0.17.0 K8S_SIDECAR_VERSION=2.7.3 DRILLDOWN_VERSION=2.0.4 ./upgrade.sh"
   exit 1
 fi
+echo "Using kube-prometheus version ${KUBE_PROMETHEUS_RELEASE}"
+
+if [ -z "${K8S_SIDECAR_VERSION:-}" ]; then
+  echo "Usage: KUBE_PROMETHEUS_RELEASE=v0.17.0 K8S_SIDECAR_VERSION=2.7.3 DRILLDOWN_VERSION=2.0.4 ./upgrade.sh"
+  exit 1
+fi
+echo "Using k8s-sidecar version ${K8S_SIDECAR_VERSION}"
+
+if [ -z "${DRILLDOWN_VERSION:-}" ]; then
+  echo "Usage: KUBE_PROMETHEUS_RELEASE=v0.17.0 K8S_SIDECAR_VERSION=2.7.3 DRILLDOWN_VERSION=2.0.4 ./upgrade.sh"
+  exit 1
+fi
+echo "Using drilldown version ${DRILLDOWN_VERSION}"
 
 ../../utils/pull-upstream.sh "${KUBE_PROMETHEUS_RELEASE}" grafana
 
@@ -30,6 +43,8 @@ yq -i 'del(.spec.template.spec.volumes[] | select(.name == "grafana-dashboard-no
 
 echo "Deployment patched"
 
-K8S_SIDECAR_RELEASE=$(curl -sL "https://api.github.com/repos/kiwigrid/k8s-sidecar/releases/latest" | jq -r ".tag_name")
-yq -i "(.images[] | select(.name == \"kiwigrid/k8s-sidecar\")).newTag = \"${K8S_SIDECAR_RELEASE}\"" kustomization.yaml
-echo "K8S sidecar updated to ${K8S_SIDECAR_RELEASE}"
+kustomize edit set image kiwigrid/k8s-sidecar=registry.sighup.io/fury/kiwigrid/k8s-sidecar:${K8S_SIDECAR_VERSION}
+echo "K8S sidecar updated to ${K8S_SIDECAR_VERSION}"
+
+yq -i "(.spec.template.spec.containers[].env[] | select(.name == \"GF_INSTALL_PLUGINS\")).value = \"https://storage.googleapis.com/integration-artifacts/grafana-lokiexplore-app/release/${DRILLDOWN_VERSION}/any/grafana-lokiexplore-app-${DRILLDOWN_VERSION}.zip;grafana-lokiexplore-app\"" patches/grafana-env.yaml
+echo "Drilldown plugin updated to ${DRILLDOWN_VERSION}"

--- a/katalog/kube-proxy-metrics/kustomization.yaml
+++ b/katalog/kube-proxy-metrics/kustomization.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring

--- a/katalog/kube-proxy-metrics/upgrade.sh
+++ b/katalog/kube-proxy-metrics/upgrade.sh
@@ -11,5 +11,5 @@ if [ -z "${RBAC_PROXY_VERSION:-}" ]; then
 fi
 echo "Using image version ${RBAC_PROXY_VERSION}"
 
-yq -i "(.images[] | select(.name == \"kube-rbac-proxy\")).newTag = \"${RBAC_PROXY_VERSION}\"" kustomization.yaml
+kustomize edit set image kube-rbac-proxy=registry.sighup.io/fury/brancz/kube-rbac-proxy:${RBAC_PROXY_VERSION}
 echo "Kube RBAC proxy updated to ${RBAC_PROXY_VERSION}"

--- a/katalog/minio-ha/kustomization.yaml
+++ b/katalog/minio-ha/kustomization.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring

--- a/katalog/minio-ha/upgrade.sh
+++ b/katalog/minio-ha/upgrade.sh
@@ -35,7 +35,7 @@ echo "Extracted archive"
 helm lint /tmp/minio-chainguard/helm/minio --values MAINTENANCE.values.yaml
 echo "Helm lint done"
 
-yq -i "(.images[] | select(.name == \"registry.sighup.io/fury/minio/mc\")).newTag = \"${MC_VERSION}\"" kustomization.yaml
+kustomize edit set image registry.sighup.io/fury/minio/mc:${MC_VERSION}
 echo "Updated image tags in kustomization.yaml"
 
 yq -i ".image.tag = \"${MINIO_IMAGE_TAG}\"" MAINTENANCE.values.yaml


### PR DESCRIPTION
### Summary 💡

Enable Grafana Drilldown dashboard plugin.


### Description 📝

Enable Grafana Drilldown dashboard plugin.
<img width="1801" height="863" alt="Screenshot 2026-06-05 at 12 08 30" src="https://github.com/user-attachments/assets/d37f3930-383a-4713-a921-0e184c98d075" />

<img width="1801" height="863" alt="Screenshot 2026-06-05 at 12 08 41" src="https://github.com/user-attachments/assets/6ccc9fe9-00f7-49bd-a1df-66757097b0b9" />



### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2805

### Future work 🔧

Not planned.
