### PR TITLE
fix: x509 permission for etcd certificates

### DIFF
--- a/katalog/x509-exporter/MAINTENANCE.values.yaml
+++ b/katalog/x509-exporter/MAINTENANCE.values.yaml
@@ -31,6 +31,16 @@ hostPathsExporter:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - DAC_READ_SEARCH
       watchFiles:
         # Common kubelet files
         - /var/lib/kubelet/pki/kubelet-server-current.pem

--- a/katalog/x509-exporter/deploy.yaml
+++ b/katalog/x509-exporter/deploy.yaml
@@ -357,6 +357,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
+              add:
+                - DAC_READ_SEARCH
               drop:
                 - ALL
             readOnlyRootFilesystem: true


### PR DESCRIPTION
### Summary 💡

This PR aims to fix the permissions issues while watching certificates owned by etcd.
Closes: #221 

### Description 📝

#### Problem
The x509-certificate-exporter-control-plane DaemonSet cannot read etcd PKI certificates:
```
msg="failed to parse \"/etc/etcd/pki/apiserver-etcd-client.crt\": stat apiserver-etcd-client.crt: permission denied"
```

#### Cause

Two changes interact to cause the bug:

##### 1. `installer-on-premises` (PR [#148](https://github.com/sighupio/installer-on-premises/pull/148) + PR [#163](https://github.com/sighupio/installer-on-premises/pull/163))

etcd PKI directory ownership changed from `root:root 0750` to `etcd:etcd 0700`. Only the `etcd` user can now traverse `/etc/etcd/pki` and `/etc/etcd/pki/etcd`.

##### 2. `module-monitoring` (x509-certificate-exporter chart)

The container runs as root but drops all capabilities (`drop: ALL`). Without `CAP_DAC_OVERRIDE`, even root must obey Unix file permissions — so it cannot enter `etcd:etcd 0700` directories.

Other watched paths (`/var/lib/kubelet/pki`, `/etc/kubernetes/pki`) are `root:root 0755/0750` and work fine.

| Path | Owner | Mode | Readable without `DAC_OVERRIDE`? |
|------|-------|------|------|
| `/etc/etcd/pki` | etcd:etcd | 0700 | **NO** |
| `/etc/etcd/pki/etcd` | etcd:etcd | 0700 | **NO** |
| `/etc/kubernetes/pki` | root:root | 0750 | YES |

#### Fix

Add `CAP_DAC_OVERRIDE` to the control-plane DaemonSet in `MAINTENANCE.values.yaml`:

```yaml
capabilities:
  drop:
    - ALL
  add:
    - DAC_OVERRIDE
```

#### Why this is safe

- The container already runs as root with hostPath mounts — `DAC_OVERRIDE` doesn't change the security boundary.
- `DAC_OVERRIDE` is in the default root capability set; we follow `drop ALL` + `add only what's needed`.
- The etcd permissions (`etcd:etcd 0700`) are correct per CIS Benchmark 1.1.11–1.1.12 and required for etcd to run as a non-root user. Changing them would break CIS compliance or etcd itself.

> **Note on CIS 5.2.9** (Minimize containers with capabilities assigned): adding `DAC_OVERRIDE` adds to existing WARNs already triggered by other SD components (`NET_BIND_SERVICE` on ingress-controller and coredns, `SYS_TIME` on node-exporter). This is an accepted trade-off — without it, CIS 1.1.11–1.1.12 (etcd PKI permissions) and the exporter cannot coexist.



### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-monitoring/2812

- I verified that the metrics for those certificates are exported and that x509 is not reporting those errors.

### Future work 🔧

Not planned.