### PR TITLE
fix: update x509-exporter paths to use kubelet-server-current.pem instead of kubelet.crt

### DIFF
--- a/katalog/x509-exporter/MAINTENANCE.values.yaml
+++ b/katalog/x509-exporter/MAINTENANCE.values.yaml
@@ -15,7 +15,7 @@ hostPathsExporter:
   daemonSets:
     data-plane:
       watchFiles:
-        - /var/lib/kubelet/pki/kubelet.crt
+        - /var/lib/kubelet/pki/kubelet-server-current.pem
         - /var/lib/kubelet/pki/kubelet-client-current.pem
       watchKubeconfFiles:
         - /etc/kubernetes/kubelet.conf
@@ -33,7 +33,7 @@ hostPathsExporter:
           effect: NoSchedule
       watchFiles:
         # Common kubelet files
-        - /var/lib/kubelet/pki/kubelet.crt
+        - /var/lib/kubelet/pki/kubelet-server-current.pem
         - /var/lib/kubelet/pki/kubelet-client-current.pem
         # Control plane specific files
         - /etc/etcd/pki/apiserver-etcd-client.crt

--- a/katalog/x509-exporter/deploy.yaml
+++ b/katalog/x509-exporter/deploy.yaml
@@ -105,7 +105,7 @@ data:
         name: host-paths-control-plane
         followSymlinks: true
         paths:
-          - /mnt/watch/file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f/var/lib/kubelet/pki/kubelet.crt
+          - /mnt/watch/file-4e011152ff1166efb100401a2542aa835a398acc/var/lib/kubelet/pki/kubelet-server-current.pem
           - /mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b/var/lib/kubelet/pki/kubelet-client-current.pem
           - /mnt/watch/file-d53b89938a3d439c2fc32700f21b9a6d3d5e280b/etc/etcd/pki/apiserver-etcd-client.crt
           - /mnt/watch/file-c8e6234df1c5e705baa1abe5cd91a672353607a4/etc/etcd/pki/etcd/ca.crt
@@ -126,7 +126,7 @@ data:
         # that escapes raises x509_source_errors_total{reason="out_of_scope_symlink"}.
         pathMappings:
           - from: "/var/lib/kubelet/pki"
-            to: "/mnt/watch/file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f/var/lib/kubelet/pki"
+            to: "/mnt/watch/file-4e011152ff1166efb100401a2542aa835a398acc/var/lib/kubelet/pki"
           - from: "/var/lib/kubelet/pki"
             to: "/mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b/var/lib/kubelet/pki"
           - from: "/etc/etcd/pki"
@@ -212,7 +212,7 @@ data:
         name: host-paths-data-plane
         followSymlinks: true
         paths:
-          - /mnt/watch/file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f/var/lib/kubelet/pki/kubelet.crt
+          - /mnt/watch/file-4e011152ff1166efb100401a2542aa835a398acc/var/lib/kubelet/pki/kubelet-server-current.pem
           - /mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b/var/lib/kubelet/pki/kubelet-client-current.pem
         # Map host-namespace path prefixes (where symlink targets are
         # recorded) to the paths the exporter actually sees inside the pod.
@@ -221,7 +221,7 @@ data:
         # that escapes raises x509_source_errors_total{reason="out_of_scope_symlink"}.
         pathMappings:
           - from: "/var/lib/kubelet/pki"
-            to: "/mnt/watch/file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f/var/lib/kubelet/pki"
+            to: "/mnt/watch/file-4e011152ff1166efb100401a2542aa835a398acc/var/lib/kubelet/pki"
           - from: "/var/lib/kubelet/pki"
             to: "/mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b/var/lib/kubelet/pki"
         formats: [pem]
@@ -334,7 +334,7 @@ spec:
       labels:
         app: x509-certificate-exporter
       annotations:
-        checksum/config: 20a830319f08a70d635a01e86a11779f13315b5f8099a30028a1a1d34afc80d1
+        checksum/config: 020224eaec78ccc088524fcd47a427ab32661fde460c852fdbc9f2836cd71118
     spec:
       serviceAccountName: x509-certificate-exporter-node
       affinity:
@@ -377,8 +377,8 @@ spec:
             - name: config
               mountPath: /etc/x509-certificate-exporter
               readOnly: true
-            - name: file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f
-              mountPath: /mnt/watch/file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f/var/lib/kubelet/pki
+            - name: file-4e011152ff1166efb100401a2542aa835a398acc
+              mountPath: /mnt/watch/file-4e011152ff1166efb100401a2542aa835a398acc/var/lib/kubelet/pki
               readOnly: true
             - name: file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b
               mountPath: /mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b/var/lib/kubelet/pki
@@ -454,7 +454,7 @@ spec:
         - name: config
           configMap:
             name: x509-certificate-exporter-control-plane
-        - name: file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f
+        - name: file-4e011152ff1166efb100401a2542aa835a398acc
           hostPath:
             path: /var/lib/kubelet/pki
             type: "Directory"
@@ -548,7 +548,7 @@ spec:
       labels:
         app: x509-certificate-exporter
       annotations:
-        checksum/config: 20a830319f08a70d635a01e86a11779f13315b5f8099a30028a1a1d34afc80d1
+        checksum/config: 020224eaec78ccc088524fcd47a427ab32661fde460c852fdbc9f2836cd71118
     spec:
       serviceAccountName: x509-certificate-exporter-node
       securityContext:
@@ -580,8 +580,8 @@ spec:
             - name: config
               mountPath: /etc/x509-certificate-exporter
               readOnly: true
-            - name: file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f
-              mountPath: /mnt/watch/file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f/var/lib/kubelet/pki
+            - name: file-4e011152ff1166efb100401a2542aa835a398acc
+              mountPath: /mnt/watch/file-4e011152ff1166efb100401a2542aa835a398acc/var/lib/kubelet/pki
               readOnly: true
             - name: file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b
               mountPath: /mnt/watch/file-9dff78b77fe2f4b0f34f77796df3fea5983e5d4b/var/lib/kubelet/pki
@@ -609,7 +609,7 @@ spec:
         - name: config
           configMap:
             name: x509-certificate-exporter-data-plane
-        - name: file-d29c5fbfbd5b6baa2cfa845e55e8f8fa2ee3d73f
+        - name: file-4e011152ff1166efb100401a2542aa835a398acc
           hostPath:
             path: /var/lib/kubelet/pki
             type: "Directory"
@@ -640,7 +640,7 @@ spec:
       labels:
         app: x509-certificate-exporter
       annotations:
-        checksum/config: 20a830319f08a70d635a01e86a11779f13315b5f8099a30028a1a1d34afc80d1
+        checksum/config: 020224eaec78ccc088524fcd47a427ab32661fde460c852fdbc9f2836cd71118
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
### Summary 💡

This edits aims to fix that we are not exporting certificate metrics for the new kubelet certificate name.


### Description 📝

This edits aims to fix that we are not exporting certificate metrics for the new kubelet certificate name.
https://github.com/sighupio/distribution/issues/512

Note: upstream chart is generating the random new path `/mnt/watch/file-4e011152ff1166efb100401a2542aa835a398acc` so it's not done manually and is as expected.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2808

I checked that x509 is exporting metrics for the new name and removed ones for the old name.

### Future work 🔧

Handle old certificate removal.