### PR TITLE
fix: Grafana dashboards

### DIFF
--- a/katalog/configs/bases/coredns/dashboards/coredns.json
+++ b/katalog/configs/bases/coredns/dashboards/coredns.json
@@ -881,11 +881,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (instance,pod,proto) (irate(coredns_forward_requests_total{job=\"kube-dns\",instance=~\"$instance\"}[2m]))",
+          "expr": "sum by (instance,pod,to) (irate(coredns_proxy_request_duration_seconds_count{job=\"kube-dns\",instance=~\"$instance\",proxy_name=\"forward\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{ pod }}/{{ proto }}",
+          "legendFormat": "{{ pod }}/{{ to }}",
           "refId": "A"
         }
       ],
@@ -967,26 +967,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le,instance,pod,proto) (rate(coredns_forward_request_duration_seconds_bucket{job=\"kube-dns\",instance=~\"$instance\"}[2m])))",
+          "expr": "histogram_quantile(0.99, sum by (le,instance,pod,to) (rate(coredns_proxy_request_duration_seconds_bucket{job=\"kube-dns\",instance=~\"$instance\",proxy_name=\"forward\"}[2m])))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ pod }}/{{ proto }} p99",
+          "legendFormat": "{{ pod }}/{{ to }} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.90, sum by (le,instance,pod,proto) (rate(coredns_forward_request_duration_seconds_bucket{job=\"kube-dns\",instance=~\"$instance\"}[2m])))",
+          "expr": "histogram_quantile(0.90, sum by (le,instance,pod,to) (rate(coredns_proxy_request_duration_seconds_bucket{job=\"kube-dns\",instance=~\"$instance\",proxy_name=\"forward\"}[2m])))",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 2,
-          "legendFormat": "{{ pod }}/{{ proto }} p90",
+          "legendFormat": "{{ pod }}/{{ to }} p90",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le,instance,pod,proto) (rate(coredns_forward_request_duration_seconds_bucket{job=\"kube-dns\",instance=~\"$instance\"}[2m])))",
+          "expr": "histogram_quantile(0.50, sum by (le,instance,pod,to) (rate(coredns_proxy_request_duration_seconds_bucket{job=\"kube-dns\",instance=~\"$instance\",proxy_name=\"forward\"}[2m])))",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 2,
-          "legendFormat": "{{ pod }}/{{ proto }} p50",
+          "legendFormat": "{{ pod }}/{{ to }} p50",
           "refId": "C"
         }
       ],

--- a/katalog/kube-state-metrics/MAINTENANCE.md
+++ b/katalog/kube-state-metrics/MAINTENANCE.md
@@ -17,4 +17,4 @@ To prepare a new release of this package:
 
 4. Update the `kustomization.yaml` file with the new image.
 
-5. Note on `--resources` flag: kube-state-metrics 2.18.0 replaced `endpoints` with `endpointslices` as the default resource. The flag `--resources=endpoints,endpointslices` is required to keep `kube_endpoint_address` metrics (used by `MimirGossipMembersEndpointsOutOfSync` alert in `katalog/mimir/prometheusRules.yaml`). Without this flag, the alert breaks because `kube_endpoint_address` is no longer emitted.
+5. Note on `--resources` flag: starting from KSM v2.18.0, `endpoints` was removed from the default resources (replaced by `endpointslices`). However, `endpoints` is still needed because `kube_endpoint_address` is used by the `MimirGossipMembersEndpointsOutOfSync` alert in `katalog/mimir/prometheusRules.yaml`. Since the `--resources` flag replaces the entire default list, the deployment explicitly lists all 28 default resources plus `endpoints`. When updating KSM, fetch the new default list from `pkg/options/resource.go` in the `kubernetes/kube-state-metrics` repository at the target version tag, append `endpoints`, and update the flag accordingly.

--- a/katalog/kube-state-metrics/deployment.yaml
+++ b/katalog/kube-state-metrics/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - args:
         - --host=127.0.0.1
         - --port=8081
-        - --resources=endpoints,endpointslices
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpointslices,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments,endpoints
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0

--- a/katalog/prometheus-operated/kustomization.yaml
+++ b/katalog/prometheus-operated/kustomization.yaml
@@ -91,3 +91,14 @@ patches:
             - get
             - list
             - watch
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups:
+            - discovery.k8s.io
+          resources:
+            - endpointslices
+          verbs:
+            - get
+            - list
+            - watch

--- a/katalog/x509-exporter/MAINTENANCE.md
+++ b/katalog/x509-exporter/MAINTENANCE.md
@@ -39,3 +39,7 @@ To update the x509-exporter package, follow these steps.
    > **Note:** Chart v4.1.0 ships a broken `X509ExporterReadErrors` alert referencing the removed `x509_read_errors` metric. The `patch_4.1.0.sh` script backports the fix from [v4.2.0-rc.1](https://github.com/enix/x509-certificate-exporter/releases/tag/v4.2.0-rc.1). When we upgrade to chart ≥4.2.0, the patch script can be removed entirely.
 
 4. Sync the new image to our registry in the [`monitoring` images.yaml file container-image-sync repository](https://github.com/sighupio/container-image-sync/blob/main/modules/monitoring/images.yml).
+
+## Notes
+
+The `securityContext` block with the `DAC_READ_SEARCH` capability in `MAINTENANCE.values.yaml` under `hostPathsExporter.daemonSets.control-plane` is required because the [on-prem installer](https://github.com/sighupio/installer-on-premises/pull/163) restricts permissions on `/etc/etcd/pki` to the `etcd` user. Without this capability, the exporter cannot read etcd certificates and logs `permission denied` errors. See [#221](https://github.com/sighupio/module-monitoring/issues/221) and fix commit `2c33b03` for context.

--- a/katalog/x509-exporter/MAINTENANCE.md
+++ b/katalog/x509-exporter/MAINTENANCE.md
@@ -26,7 +26,7 @@ To update the x509-exporter package, follow these steps.
    - Download the Grafana dashboard JSON into `config/x509-certificate-exporter.json`
    - Patch all labels to `app: x509-certificate-exporter` (with `prometheus: k8s` and `role: alert-rules` on `PrometheusRule`)
    - Patch `spec.selector` and `spec.template.metadata.labels` on DaemonSets, Deployment and Service
-   - For chart 4.1.0, run `patch_4.1.0.sh` to replace the broken `X509ExporterReadErrors` alert with `SourceErrors`/`SourceErrorsSustained` from chart v4.2.0-rc.1
+   - For chart 4.1.0, run `patch_4.1.0.sh` to replace the broken `X509ExporterReadErrors` alert with `SourceErrors`/`SourceErrorsSustained` and related Grafana dahboard from chart v4.2.0-rc.1
    - Run `mise run add-license`
 
 3. Review the changes:

--- a/katalog/x509-exporter/MAINTENANCE.values.yaml
+++ b/katalog/x509-exporter/MAINTENANCE.values.yaml
@@ -10,7 +10,7 @@ image:
 grafana:
   # We create the ConfigMap manually because automatic creation generates a non-human-readable one-line resource.
   createDashboard: false
-
+exposeNotBeforeMetric: true
 hostPathsExporter:
   daemonSets:
     data-plane:

--- a/katalog/x509-exporter/config/x509-certificate-exporter.json
+++ b/katalog/x509-exporter/config/x509-certificate-exporter.json
@@ -483,7 +483,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(x509_read_errors)",
+          "expr": "count(x509_source_errors_total)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -550,7 +550,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(x509_read_errors)",
+          "expr": "sum(x509_source_errors_total)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -1713,7 +1713,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(x509_read_errors)",
+          "expr": "count(x509_source_errors_total)",
           "interval": "",
           "legendFormat": "exporters",
           "queryType": "randomWalk",
@@ -1810,7 +1810,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum (x509_read_errors > bool 0)",
+          "expr": "sum (x509_source_errors_total > bool 0)",
           "interval": "",
           "legendFormat": "exporters with errors",
           "queryType": "randomWalk",
@@ -1908,7 +1908,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(x509_read_errors[15m]))",
+          "expr": "sum(rate(x509_source_errors_total[15m]))",
           "interval": "",
           "legendFormat": "error rate",
           "queryType": "randomWalk",
@@ -2005,7 +2005,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(x509_read_errors)",
+          "expr": "sum(x509_source_errors_total)",
           "interval": "",
           "legendFormat": "errors",
           "queryType": "randomWalk",
@@ -2105,7 +2105,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, rate(x509_read_errors[6h]))",
+          "expr": "topk(10, rate(x509_source_errors_total[6h]))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -2199,7 +2199,7 @@
           "datasource": {
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, x509_read_errors)",
+          "expr": "topk(10, x509_source_errors_total)",
           "format": "table",
           "instant": true,
           "interval": "",

--- a/katalog/x509-exporter/deploy.yaml
+++ b/katalog/x509-exporter/deploy.yaml
@@ -44,7 +44,7 @@ data:
     metrics:
       exposeRelative: false
       exposePerCertError: false
-      exposeNotBefore: false
+      exposeNotBefore: true
       exposeExpired: true
       exposeDiagnostics: false
 
@@ -90,7 +90,7 @@ data:
     metrics:
       exposeRelative: false
       exposePerCertError: false
-      exposeNotBefore: false
+      exposeNotBefore: true
       exposeExpired: true
       exposeDiagnostics: false
       trimPathComponents: 3
@@ -197,7 +197,7 @@ data:
     metrics:
       exposeRelative: false
       exposePerCertError: false
-      exposeNotBefore: false
+      exposeNotBefore: true
       exposeExpired: true
       exposeDiagnostics: false
       trimPathComponents: 3
@@ -334,7 +334,7 @@ spec:
       labels:
         app: x509-certificate-exporter
       annotations:
-        checksum/config: 020224eaec78ccc088524fcd47a427ab32661fde460c852fdbc9f2836cd71118
+        checksum/config: 1b93763923bd6d41ad44590324423253b74959117dcd093e823b79e73f44fa0c
     spec:
       serviceAccountName: x509-certificate-exporter-node
       affinity:
@@ -550,7 +550,7 @@ spec:
       labels:
         app: x509-certificate-exporter
       annotations:
-        checksum/config: 020224eaec78ccc088524fcd47a427ab32661fde460c852fdbc9f2836cd71118
+        checksum/config: 1b93763923bd6d41ad44590324423253b74959117dcd093e823b79e73f44fa0c
     spec:
       serviceAccountName: x509-certificate-exporter-node
       securityContext:
@@ -642,7 +642,7 @@ spec:
       labels:
         app: x509-certificate-exporter
       annotations:
-        checksum/config: 020224eaec78ccc088524fcd47a427ab32661fde460c852fdbc9f2836cd71118
+        checksum/config: 1b93763923bd6d41ad44590324423253b74959117dcd093e823b79e73f44fa0c
     spec:
       securityContext:
         runAsNonRoot: true

--- a/katalog/x509-exporter/patch_4.1.0.sh
+++ b/katalog/x509-exporter/patch_4.1.0.sh
@@ -16,6 +16,10 @@ helm template x509-certificate-exporter /tmp/x509-certificate-exporter \
   --values MAINTENANCE.values.yaml > /tmp/x509-certificate-exporter/deploy.yaml
 echo "Built chart template in /tmp/x509-certificate-exporter/deploy.yaml"
 
+wget -q "https://raw.githubusercontent.com/enix/x509-certificate-exporter/refs/tags/v4.2.0-rc.1/chart/grafana-dashboards/x509-certificate-exporter.json" \
+  -O config/x509-certificate-exporter.json
+echo "Downloaded Grafana dashboard in config/x509-certificate-exporter.json"
+
 yq 'select(.kind == "PrometheusRule").spec.groups[].rules | map(select(.alert == "SourceErrors" or .alert == "SourceErrorsSustained"))' \
   /tmp/x509-certificate-exporter/deploy.yaml | sed '/^#/d' > /tmp/x509-certificate-exporter/patch-alerts.yaml
 yq -i 'select(.kind == "PrometheusRule").spec.groups[].rules |= map(select(.alert != "X509ExporterReadErrors"))' deploy.yaml


### PR DESCRIPTION
### Summary 💡

Fix regressions of Grafana Dashboard from previous upgrade PRs.

### Description 📝

- Updated version of Prometheus uses endpointslices instead of endpoints so RBAC adjustment was needed.
- kube-state-metrics do not expose `endpoints` by default (in favor of `endpointslices`) but it's still used by Mimir so we need to explictly enable it. There isn't a way to enable only `endpoints` other than the default ones so we need to explicit the complete list (picked up from the default list).
- Picked up x509 Grafana dashboard from helm chart 4.2.0-rc1 because in 4.1.0 (generally from 4.0) it's broken.
- Fix CoreDNS dashboard that used removed metrics.
- Enable `exposeNotBefore` metrics for x509 exporter
- Added doc for `DAC_READ_SEARCH` about PR #242 

Other broken dashboards reported in https://github.com/sighupio/module-monitoring/issues/244

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-monitoring/2847
- Tested in a local cluster that these changes fixed related dashbords.

Tested on local k8s cluster.

### Future work 🔧

Not planned.