### PR TITLE
fix: update prometheus-config-reloader image registry

### DIFF
--- a/katalog/prometheus-operator/deployment.yaml
+++ b/katalog/prometheus-operator/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.89.0
+        - --prometheus-config-reloader=registry.sighup.io/fury/prometheus-operator/prometheus-config-reloader:v0.89.0
         - --watch-referenced-objects-in-all-namespaces=true
         - --disable-unmanaged-prometheus-configuration=true
         - --kubelet-endpoints=true

--- a/katalog/prometheus-operator/kustomization.yaml
+++ b/katalog/prometheus-operator/kustomization.yaml
@@ -25,16 +25,6 @@ patches:
           spec:
             securityContext:
               runAsGroup: 65534
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: prometheus-operator
-      namespace: monitoring
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/args/1
-        value: --prometheus-config-reloader=registry.sighup.io/fury/prometheus-operator/prometheus-config-reloader:v0.85.0
 
 resources:
   - clusterRole.yaml

--- a/utils/pull-upstream.sh
+++ b/utils/pull-upstream.sh
@@ -193,6 +193,8 @@ case "${FURY_MODULE}" in
     populate_package "prometheusOperator"
 
     cp -af "${WORK_DIR}"/manifests/setup/0* "${KATALOG_PATH}/prometheus-operator/crds"
+    sed -i '' 's|quay.io/prometheus-operator/prometheus-config-reloader|registry.sighup.io/fury/prometheus-operator/prometheus-config-reloader|g' \
+      "${KATALOG_PATH}/prometheus-operator/deployment.yaml"
     ;;
   *)
     echo "$(basename "$0"): error: unknown package ${FURY_MODULE}" 1>&2


### PR DESCRIPTION
### Summary 💡

fix: update prometheus-config-reloader image registry and cleanup old kustomization patch

### Description 📝

Update prometheus-config-reloader image registry and cleanup old kustomization patch.
Changed the patch approach from kustomization.yaml to bash script to avoid forgetting it.


### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-monitoring/2863

### Future work 🔧

Not planned.