### PR TITLE
docs: refactor module documentation, drop legacy Furyfile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,40 +15,19 @@
 
 <!-- <SD-DOCS> -->
 
-**Monitoring Module** provides a fully-fledged monitoring stack for the
-[SIGHUP Distribution (SD)][repo]. This module extends and improves upon the [Kube-Prometheus][kube-prometheus-link] project.
+**Monitoring Module** provides a fully-fledged monitoring stack for [SIGHUP Distribution (SD)][kfd-repo]. This module extends and improves upon the [Kube-Prometheus][kube-prometheus-link] project.
 
-If you are new to SD please refer to the [official documentation][docs] on how to get started with SD.
+If you are new to SD please refer to the [official documentation][kfd-docs] on how to get started with SD.
 
 ## Overview
 
-This module is designed to give you full control and visibility over your
-cluster operations. Metrics from the cluster and the applications are collected
-and clean analytics are offered via a visualization platform, [Grafana][grafana-link].
+This module gives you full control and visibility over your cluster operations: metrics from the cluster and your applications are collected by [Prometheus][prometheus-link] and visualized through [Grafana][grafana-link]. The stack is built around the `prometheus-operator`, which manages Prometheus, [Alertmanager][alertmanager-link] and `ServiceMonitor` resources as Kubernetes-native controllers.
 
-The centerpiece of this module is the [`prometheus-operator`], which offers the
-easy deployment of the following as controllers:
-
-- [Prometheus][prometheus-link]: An open-source monitoring and alerting toolkit for cloud-native applications
-- [Alertmanager][alertmanager-link]: Manages alerts sent by the Prometheus server and route them through receiver integrations such as email, Slack, or PagerDuty
-- [ServiceMonitor][servicemonitor-link]: Declaratively specifies how groups of services should be monitored, by automatically generating Prometheus scrape configuration based on the definition
-
-Since the export of certain metrics can be heavily cloud-provider specific, we
-provide a bunch of cloud-provider specific configurations. The setups we
-currently support include:
-
-- Google Kubernetes Engine (GKE)
-- Azure Kubernetes Service (AKS)
-- Elastic Kubernetes Service (EKS)
-- on-premises or self-managed cloud clusters
-
-Most of the components in this module are deployed in namespace `monitoring`, unless the
-functionality requires permissions that force it to be deployed in the
-namespace `kube-system`.
+Provider-specific `ServiceMonitors` (EKS, AKS, GKE and on-premises/self-managed clusters) are selected and deployed automatically based on your cluster, so the right Kubernetes components metrics are collected without manual configuration. Most components run in the `monitoring` namespace, except those that require permissions that force them into `kube-system`.
 
 ## Packages
 
-Monitoring Module provides the following packages:
+The following packages are included in Monitoring Module:
 
 | Package                                                | Version  | Description                                                                                                               |
 | ------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -65,19 +44,9 @@ Monitoring Module provides the following packages:
 | [mimir](katalog/mimir)                                 | `3.0.4`  | Mimir is an open source, horizontally scalable, highly available, multi-tenant TSDB for long-term storage for Prometheus. |
 | [haproxy](katalog/haproxy)                             | `N.A.`   | Grafana dashboards and Prometheus rules (alerts) for HAproxy.                                                             |
 
-### Integration with cloud providers
+The module also ships the provider-specific ServiceMonitor packages (`eks-sm`, `aks-sm`, `gke-sm`, `kubeadm-sm`), which are selected and deployed automatically based on your cluster's provider.
 
-One of the following components can be used to enable service monitoring in each
-cloud environment:
-
-| Component                        | Description                                                                                                    |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [aks-sm](katalog/aks-sm)         | ServiceMonitor to collect Kubernetes components metrics from AKS                                               |
-| [gke-sm](katalog/gke-sm)         | ServiceMonitor to collect Kubernetes components metrics from GKE                                               |
-| [eks-sm](katalog/eks-sm)         | ServiceMonitor to collect Kubernetes components metrics from EKS                                               |
-| [kubeadm-sm](katalog/kubeadm-sm) | ServiceMonitors, Prometheus rules and alerts for Kubernetes components of self-managed or on-premises clusters |
-
-Please refer to the individual package documentation for further details.
+Click on each package to see its full documentation.
 
 ## Compatibility
 
@@ -92,142 +61,63 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ## Usage
 
-### Prerequisites
+**Monitoring Module** is part of SIGHUP Distribution (SD) and is deployed automatically by [`furyctl`][furyctl-repo] when you create or update a cluster. You don't need to download, vendor or install its packages manually.
 
-| Tool                        | Version    | Description                                                                                                                                                    |
-| --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.32.5` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].      |
-| [kustomize][kustomize-repo] | `>=5.6.0`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
+### Configuration
 
-### Deployment with furyctl legacy
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
+You choose whether and how to deploy the monitoring stack under `spec.distribution.modules.monitoring` in your `furyctl.yaml`: the `type` field selects the flavor (`prometheus`, `prometheusAgent` or `mimir`), or disables the module entirely with `none`. The other fields let you customize the individual packages; the ones you leave out are deployed with sensible defaults.
 
 ```yaml
-versions:
-  monitoring: v4.2.0
-
-bases:
-    - name: monitoring/prometheus-operator
-    - name: monitoring/prometheus-operated
-    - name: monitoring/alertmanager-operated
-    - name: monitoring/blackbox-exporter
-    - name: monitoring/kube-proxy-metrics
-    - name: monitoring/kube-state-metrics
-    - name: monitoring/grafana
-    - name: monitoring/node-exporter
-    - name: monitoring/prometheus-adapter
-    - name: monitoring/x509-exporter
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      monitoring:
+        # Monitoring stack flavor: none, prometheus, prometheusAgent or mimir
+        type: prometheus
+        prometheus:
+          retentionTime: 30d
+          retentionSize: 120GB
+          storageSize: 150Gi
+        alertmanager:
+          installDefaultRules: true
+          slackWebhookUrl: https://hooks.slack.com/services/XXXXXX
 ```
 
-Along with the primary components, include one of the following components,
-based on your cloud provider for service monitoring:
-
-- ServiceMonitor for AWS EKS cluster
+To keep metrics for the long term, set `type: mimir` and configure the `mimir` block with its storage backend (`minio` for an in-cluster MinIO, or `externalEndpoint` for an external S3-compatible bucket):
 
 ```yaml
-  ...
-  - name: monitoring/eks-sm
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      monitoring:
+        type: mimir
+        mimir:
+          retentionTime: 30d
+          backend: minio
 ```
 
-- ServiceMonitor for Azure AKS cluster
+See the configuration reference for your cluster kind for the full list of available options: [EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd] or [OnPremises][schema-reference-onprem].
 
-```yaml
-  ...
-  - name: monitoring/aks-sm
-```
-
-- ServiceMonitor for GCP GKE cluster
-
-```yaml
-  ...
-  - name: monitoring/gke-sm
-```
-
-- ServiceMonitor for on-premises and self-managed cluster
-
-```yaml
-  ...
-  - name: monitoring/kubeadm-sm
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/monitoring`.
-
-4. To deploy the packages to your cluster, define a `kustomization.yaml` with the
-following content:
-
-```yaml
-bases:
-    - ./vendor/katalog/monitoring/prometheus-operator
-    - ./vendor/katalog/monitoring/prometheus-operated
-    - ./vendor/katalog/monitoring/alertmanager-operated
-    - ./vendor/katalog/monitoring/blackbox-exporter
-    - ./vendor/katalog/monitoring/kube-proxy-metrics
-    - ./vendor/katalog/monitoring/kube-state-metrics
-    - ./vendor/katalog/monitoring/grafana
-    - ./vendor/katalog/monitoring/node-exporter
-    - ./vendor/katalog/monitoring/prometheus-adapter
-    - ./vendor/katalog/monitoring/x509-exporter
-```
-
-Include in the `kustomization` also the ServiceMonitor package specific to each
-service provider as follows:
-
-- For AWS EKS
-
-```yaml
-  ...
-  - ./vendor/katalog/monitoring/eks-sm
-```
-
-- For GCP GKE
-
-```yaml
-  ...
-  - ./vendor/katalog/monitoring/gke-sm
-```
-
-- For Azure AKS
-
-```yaml
-  ...
-  - ./vendor/katalog/monitoring/aks-sm
-```
-
-- For on-premises and self-managed
-
-```yaml
-  ...
-  - ./vendor/katalog/monitoring/kubeadm-sm
-```
-
-1. To deploy the packages to your cluster, execute:
-
-```shell
-kustomize build . | kubectl apply -f - --server-side
-```
-
-### Examples
-
-To see examples of how to customize Fury Kubernetes Monitoring packages, please
-go to the [examples](examples) directory.
+To install SD from scratch, follow the [Getting started][getting-started] guide.
 
 <!-- Links -->
 
+[kfd-repo]: https://github.com/sighupio/distribution
+[furyctl-repo]: https://github.com/sighupio/furyctl
+[kfd-docs]: https://docs.sighup.io/docs/distribution/
 [kube-prometheus-link]: https://github.com/prometheus-operator/kube-prometheus
 [prometheus-link]: https://github.com/prometheus/prometheus
 [alertmanager-link]: https://github.com/prometheus/alertmanager
-[servicemonitor-link]: https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions
 [grafana-link]: https://grafana.com/
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
+[getting-started]: https://docs.sighup.io/docs/getting-started/
 [compatibility-matrix]: https://github.com/sighupio/module-monitoring/blob/main/docs/COMPATIBILITY_MATRIX.md
-[repo]: https://github.com/sighupio/distribution
-[furyctl-repo]: https://github.com/sighupio/furyctl
-[kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
-[docs]: https://docs.sighup.io/docs/distribution/
 
 <!-- </SD-DOCS> -->
 
@@ -235,14 +125,14 @@ go to the [examples](examples) directory.
 
 ## Contributing
 
-Before contributing, please read first the [Contributing Guidelines](docs/CONTRIBUTING.md).
+Before contributing, please read first the [Contributing Guidelines](https://github.com/sighupio/distribution/blob/main/docs/CONTRIBUTING.md).
 
 ### Reporting Issues
 
-In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/fury-kubernetes-networking/issues/new/choose).
+In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/module-monitoring/issues/new/choose).
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source and it's released under the following [LICENSE](LICENSE).
 
 <!-- </FOOTER> -->

--- a/examples/blackbox-exporter-probe/README.md
+++ b/examples/blackbox-exporter-probe/README.md
@@ -5,9 +5,6 @@ reachable via HTTP and HTTPS protocols using blackbox-exporter. To learn more
 about the Probe resource, see the Prometheus Operator API reference
 [documentation](https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#probespec).
 
-To deploy this example:
-
-```shell
-furyctl vendor -H
-make deploy
-```
+This example shows the `Probe` resource definition only; the Blackbox exporter
+itself is deployed as part of the Monitoring Module when you create a cluster
+with `furyctl`. See the [module documentation](../../README.md) for details.

--- a/katalog/aks-sm/README.md
+++ b/katalog/aks-sm/README.md
@@ -2,31 +2,13 @@
 
 <!-- <SD-DOCS> -->
 
-This package provides monitoring for Kubernetes components `kubelet`, `coredns` and
-`api-server` on AKS.
+## Overview
 
-## Requirements
+This package provides monitoring for the Kubernetes components `kubelet`, `coredns` and `api-server` on AKS. `api-server` and `kubelet` metrics are scraped every `30s` and `coredns` every `15s`, and it ships a set of Grafana dashboards (CoreDNS, API server, kubelet, networking and persistent volumes) for those components.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
+## Deployment
 
-## Configuration
-
-Fury distribution AKS ServiceMonitor has the following configuration:
-
-- `api-server` and `kubelet` metrics are scraped with `30s` intervals
-- `coredns` metrics are scraped with `15s` intervals
-- Dashboards shipped:
-  - `coredns`: CoreDNS >= 1.8.0
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/alertmanager-operated/README.md
+++ b/katalog/alertmanager-operated/README.md
@@ -2,66 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-Alertmanager handles alerts sent by Prometheus server and routes them to
-configured receiver integrations such as email, Slack, PageDuty, or OpsGenie. It
-helps you to manage alerts flexibly with its grouping, inhibition
-and silencing features.
+## Overview
 
-Fury Prometheus deployment (see [prometheus-operated](../prometheus-operated))
-is already configured to automatically discover Alertmanager instances deployed
-with this package.
+Alertmanager handles alerts sent by the Prometheus server and routes them to configured receiver integrations such as email, Slack, PagerDuty, or OpsGenie. It helps you manage alerts flexibly with its grouping, inhibition and silencing features. The Prometheus deployment (see [prometheus-operated](../prometheus-operated)) is already configured to automatically discover the Alertmanager instances deployed with this package.
 
-## Image repository and tag
+## Upstream project
 
-* Alertmanager image: `registry.sighup.io/prometheus/alertmanager:v0.31.1`
-* Alertmanager repository: [Alertmanager on Github][am-gh]
-* Alertmanager documentation: [Alertmanager Homepage][am-doc]
-
-## Requirements
-
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
-
-## Configuration
-
-Fury distribution Alertmanager is deployed with the following configuration:
-
-- Replica number: `3`
-- Listens on port `9093`
-- Alertmanager metrics are scraped by Prometheus every `30s`
+This package is based on the upstream [Alertmanager][am-gh].
 
 ## Deployment
 
-Before deploying this, please take a look at how to configure the alertmanager [the
-right way][example-2].
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-You can deploy Alertmanager by running the following command:
+You can customize it under `spec.distribution.modules.monitoring.alertmanager` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-```shell
-kustomize build | kubectl apply -f -
-```
-
-### Accessing Alertmanager UI
-
-You can access to the Alertmanager dashboard by port-forwarding on port 9093:
-
-```shell
-kubectl port-forward svc/alertmanager-main 9093:9093 --namespace monitoring
-```
-
-Now you can go to [http://127.0.0.1:9093](http://127.0.0.1:9093) on your browser
-to see and manage your alerts.
-
-To learn how to add external URL to access Alertmanager, please see the
-[example][example].
-
-Links
+<!-- Links -->
 
 [am-gh]: https://github.com/prometheus/alertmanager
-[am-doc]: https://prometheus.io/docs/alerting/alertmanager
-[example]: ../../examples/prometheus-alertmanager-externalUrl
-[example-2]: ../../examples/alertmanager-configuration
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/blackbox-exporter/README.md
+++ b/katalog/blackbox-exporter/README.md
@@ -1,56 +1,27 @@
-# Blackbox exporter
+# Blackbox Exporter
 
 <!-- <SD-DOCS> -->
 
-The blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP, ICMP and gRPC.
+## Overview
 
-*Source:* [prometheus/blackbox_exporter](https://github.com/prometheus/blackbox_exporter)
+The Blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP, ICMP and gRPC. It ships with probes for HTTP 2xx (GET and POST), IRC, POP3S, SSH and TCP connections, and its metrics are scraped by Prometheus.
 
-## Requirements
+## Upstream project
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
-
-## Image repository and tag
-
-- Blackbox exporter image: `registry.sighup.io/fury/prometheus/blackbox-exporter:v0.28.0`
-- Blackbox exporter repository: [Blackbox exporter on GitHub][blackbox-exporter-gh]
-- Kubernetes ConfigMap Reload image: `registry.sighup.io/fury/jimmidyson/configmap-reload:v0.15.0`
-- Kubernetes ConfigMap Reload repository: [Kubernetes ConfigMap Reload on GitHub][configmap-reload-gh]
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.21.0`
-- kube-rbac-proxy repository: [kube-rbac-proxy on GitHub][krp-gh]
-
-## Configuration
-
-Blackbox exporter is deployed with the following configuration:
-
-- Resource limits are `20m` for CPU and `40Mi` for memory
-- Listens on port 9115
-- Prometheus scrapes metrics every 30s
-- Probes available:
-  - HTTP 200 GET (`http_2xx`)
-  - HTTP 200 POST (`http_post_2xx`)
-  - IRC (`irc_banner`)
-  - POP3S (`pop3s_banner`)
-  - SSH (`ssh_banner`)
-  - TCP (`tcp_connect`)
-
-To learn how to instruct Prometheus to check Blackbox exporter probes, please see the [examples](../../examples/blackbox-exporter-probe) folder.
+This package is based on the upstream [Blackbox exporter][blackbox-exporter-gh].
 
 ## Deployment
 
-You can deploy the blackbox-exporter by running the following command:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build katalog/blackbox-exporter | kubectl apply -f - --server-side
-```
+You can customize it under `spec.distribution.modules.monitoring.blackboxExporter` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
 [blackbox-exporter-gh]: https://github.com/prometheus/blackbox_exporter
-[configmap-reload-gh]: https://github.com/jimmidyson/configmap-reload
-[krp-gh]: https://github.com/brancz/kube-rbac-proxy
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/configs/aks/README.md
+++ b/katalog/configs/aks/README.md
@@ -1,30 +1,16 @@
 # AKS ServiceMonitor
 
-This package provides monitoring for Kubernetes components `kubelet`, `coredns` and
-`api-server` on AKS.
+<!-- <SD-DOCS> -->
 
-## Requirements
+## Overview
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../../prometheus-operator)
+This package provides monitoring for the Kubernetes components `kubelet`, `coredns` and `api-server` on AKS. `api-server` and `kubelet` metrics are scraped every `30s` and `coredns` every `15s`, and it ships a set of Grafana dashboards (CoreDNS, API server, kubelet, networking and persistent volumes) for those components.
 
-## Configuration
+## Deployment
 
-Fury distribution AKS ServiceMonitor has the following configuration:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../../README.md) to learn how the Monitoring Module is installed and configured.
 
-- `api-server` and `kubelet` metrics are scraped with `30s` intervals
-- `coredns` metrics are scraped with `15s` intervals
-- Dashboards shipped:
-  - `coredns`: CoreDNS >= 1.8.0
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/configs/eks/README.md
+++ b/katalog/configs/eks/README.md
@@ -1,30 +1,16 @@
 # EKS ServiceMonitor
 
-This package provides monitoring for Kubernetes components `kubelet` and
-`api-server` on EKS.
+<!-- <SD-DOCS> -->
 
-## Requirements
+## Overview
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../../prometheus-operator)
+This package provides monitoring for the Kubernetes components `kubelet` and `api-server` on EKS. `api-server` and `kubelet` metrics are scraped every `30s` and `coredns` every `15s`, and it ships a set of Grafana dashboards (CoreDNS, API server, kubelet, networking and persistent volumes) for those components.
 
-## Configuration
+## Deployment
 
-Fury distribution EKS ServiceMonitor has the following configuration:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../../README.md) to learn how the Monitoring Module is installed and configured.
 
-- `api-server` and `kubelet` metrics are scraped with `30s` intervals
-- `coredns` metrics are scraped with `15s` intervals
-- Dashboards shipped:
-  - `coredns`: CoreDNS >= 1.8.0
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/configs/gke/README.md
+++ b/katalog/configs/gke/README.md
@@ -1,28 +1,16 @@
 # GKE ServiceMonitor
 
-This package provides monitoring for Kubernetes components `kubelet` and
-`api-server` on GKE.
+<!-- <SD-DOCS> -->
 
-## Requirements
+## Overview
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../../prometheus-operator)
+This package provides monitoring for the Kubernetes components `kubelet` and `api-server` on GKE. Metrics are scraped every `30s`, and it ships a set of Grafana dashboards (API server, kubelet, networking and persistent volumes) for those components.
 
-## Configuration
+## Deployment
 
-Fury distribution GKE ServiceMonitor has following configuration:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../../README.md) to learn how the Monitoring Module is installed and configured.
 
-- `api-server` and `kubelet` metrics are scraped with `30s` intervals
-- Dashboards shipped:
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/configs/kubeadm/README.md
+++ b/katalog/configs/kubeadm/README.md
@@ -1,81 +1,16 @@
 # Kubeadm ServiceMonitor
 
-This package provides monitoring for the following Kubernetes components:
+<!-- <SD-DOCS> -->
 
-- kubelet
-- coredns
-- api-server
-- kube-control-manager
-- kube-scheduler
-- etcd
+## Overview
 
-These are components needed to deliver a functioning Kubernetes cluster. If you
-want to learn more about these components please follow the official
-[documentation](https://kubernetes.io/docs/concepts/overview/components/) of
-Kubernetes.
+This package provides monitoring for the Kubernetes components of self-managed or on-premises clusters: `kubelet`, `coredns`, `api-server`, `kube-controller-manager`, `kube-scheduler` and `etcd`. It ships ServiceMonitors that scrape these components, a set of Grafana dashboards, and Prometheus rules and alerts for the control-plane components, CoreDNS and etcd.
 
-## Requirements
+## Deployment
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../../prometheus-operator)
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../../README.md) to learn how the Monitoring Module is installed and configured.
 
-## Configuration
-
-Prometheus scrapes Kubernetes component metrics on port `metrics` with following
-intervals:
-- kube-control-manager: `30s`
-- coredns: `15s`
-- etcd: `15s`
-- api-server: `30s`
-- kubelet: `30s`
-- kube-scheduler: `30s`
-- Dashboards shipped:
-  - `coredns`: CoreDNS >= 1.8.0
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
-  - `controller-manager`: Kubernetes / Controller Manager
-  - `etcd`: Etcd
-  - `scheduler`: Kubernetes / Scheduler
-
-## Alerts
-
-The followings alerts are already defined for this package.
-
-### kubernetes-absent-kubeadm
-
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| KubeControllerManagerDown | This alert fires if Prometheus target discovery was not able to reach the kube-controller-manager in the last 15 minutes. | critical | 15m |
-| KubeSchedulerDown | This alert fires if Prometheus target discovery was not able to reach the kube-scheduler in the last 15 minutes. | critical | 15m |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 30 days. | warning |  |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 7 days. | critical |  |
-
-### coredns
-
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| CoreDNSPanic | This alert fires if CoreDNS total panic count increased by at least 1 in the last 10 minutes. | warning |  |
-| CoreDNSRequestsLatency | This alert fires if CoreDNS 99th percentile requests latency was higher than 100ms in the last 10 minutes. | warning | 10m |
-| CoreDNSHealthRequestsLatency | This alert fires if CoreDNS 99th percentile health requests latency was higher than 10ms in the last 10 minutes. | warning | 10m |
-| CoreDNSProxyRequestsLatency | This alert fires if CoreDNS 99th percentile proxy requests latency was higher than 500ms in the last 10 minutes. | warning | 10m |
-
-### etcd3
-
-| Parameter | Description | Severity | Interval |
-|------|-------------|----------|:-----:|
-| EtcdInsufficientMembers | This alert fires if less than half of Etcd cluster members were online in the last 3 minutes. | critical | 3m |
-| EtcdNoLeader | This alert fires if the Etcd cluster had no leader in the last minute. | critical | 1m |
-| EtcdHighNumberOfLeaderChanges | This alert fires if the Etcd cluster changed leader more than 3 times in the last hour. | warning |  |
-| EtcdHighNumberOfFailedProposals | This alert fires if there were more than 5 proposal failure in the last hour. | warning |  |
-| EtcdHighFsyncDurations | This alert fires if the WAL fsync 99th percentile latency was higher than 0.5s in the last 10 minutes. | warning | 10m |
-| EtcdHighCommitDurations | This alert fires if the backend commit 99th percentile latency was higher than 0.25s in the last 10 minutes. | warning | 10m |
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/eks-sm/README.md
+++ b/katalog/eks-sm/README.md
@@ -2,31 +2,13 @@
 
 <!-- <SD-DOCS> -->
 
-This package provides monitoring for Kubernetes components `kubelet` and
-`api-server` on EKS.
+## Overview
 
-## Requirements
+This package provides monitoring for the Kubernetes components `kubelet` and `api-server` on EKS. `api-server` and `kubelet` metrics are scraped every `30s` and `coredns` every `15s`, and it ships a set of Grafana dashboards (CoreDNS, API server, kubelet, networking and persistent volumes) for those components.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
+## Deployment
 
-## Configuration
-
-Fury distribution EKS ServiceMonitor has the following configuration:
-
-- `api-server` and `kubelet` metrics are scraped with `30s` intervals
-- `coredns` metrics are scraped with `15s` intervals
-- Dashboards shipped:
-  - `coredns`: CoreDNS >= 1.8.0
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/gke-sm/README.md
+++ b/katalog/gke-sm/README.md
@@ -2,29 +2,13 @@
 
 <!-- <SD-DOCS> -->
 
-This package provides monitoring for Kubernetes components `kubelet` and
-`api-server` on GKE, the managed cluster solution by GCP.
+## Overview
 
-## Requirements
+This package provides monitoring for the Kubernetes components `kubelet` and `api-server` on GKE, the managed cluster solution by GCP. Metrics are scraped every `30s`, and it ships a set of Grafana dashboards (API server, kubelet, networking and persistent volumes) for those components.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
+## Deployment
 
-## Configuration
-
-Fury distribution GKE ServiceMonitor has the following configuration:
-
-- `api-server` and `kubelet` metrics are scraped with `30s` intervals
-- Dashboards shipped:
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/grafana/README.md
+++ b/katalog/grafana/README.md
@@ -2,77 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-Grafana is an open-source data visualization and graph composer platform for
-numeric time-series data with Prometheus integration.
+## Overview
 
-## Image repository and tag
+Grafana is an open-source data visualization and graph composer platform for numeric time-series data, integrated with Prometheus as its default data source. Grafana automatically loads dashboards from ConfigMaps labeled `grafana-sighup-dashboard` and data sources from ConfigMaps/Secrets labeled `grafana-sighup-datasource` across all namespaces, picked up by the bundled k8s-sidecar.
 
-- Grafana image: `grafana/grafana:12.4.1`
-- Grafana repository: [https://github.com/grafana/grafana](https://github.com/grafana/grafana)
-- Grafana documentation: [https://docs.grafana.org](https://docs.grafana.org)
-- k8s-sidecar image: `kiwigrid/k8s-sidecar`
-- k8s-sidecar repository: <https://github.com/kiwigrid/k8s-sidecar>
-- k8s-sidecar documentation: <https://github.com/kiwigrid/k8s-sidecar/blob/master/README.md>
+## Upstream project
 
-## Requirements
-
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-
-## Configuration
-
-Fury distribution Grafana is deployed with the following configuration:
-
-- Replica number: `1`
-- Anonymous authentication enabled
-- `Admin` role for unauthenticated users
-- Resource limits are `200m` for CPU and `200Mi` for memory
-- Listens on port `3000`
-- Prometheus configured as the data source
-
-## Add new dashboards
-
-Grafana will try to load automatically all the files inside configMaps that have the `grafana-sighup-dashboard` label from **all** namespaces.
-
-To add a custom dashboard to Grafana, follow the next steps:
-
-1. Create a configMap that includes the dashboard definition `json` file (you can include more than one json per configMap)
-2. Add the `grafana-sighup-dashboard` **label** to the configMap, the value is not important.
-3. If you want to put the dashboard(s) in a specific Grafana folder, for example `myfolder`, add the following **annotation** to the configMap: `grafana-folder: myfolder`.
-
-Look at the [dashboards](dashboards) folder `kustomization.yaml` for some examples.
-
-## Add new datasource
-
-Additionally, you can create a ConfigMap/Secret in your namespace with a datasource definition then labeling it
-with the label key `grafana-sighup-datasource`, the value of the label is up to you. Labeling it, the sidecar k8s-sidecar
-will take care of it and inject it into a shared volume and send an API reload signal to grafana itself.
-
-Look at the [datasources](datasources) folder `kustomization.yaml` for an example.
+This package is based on the upstream [Grafana][grafana-gh].
 
 ## Deployment
 
-You can deploy Grafana by running the following command:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.monitoring.grafana` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-### Accessing Grafana UI
+<!-- Links -->
 
-You can access Grafana Dashboard by port-forwarding on port `3000`:
-
-```shell
-kubectl port-forward svc/grafana 3000:3000 --namespace monitoring
-```
-
-Grafana will be available on [http://127.0.0.1:3000](http://127.0.0.1:3000) from
-your browser.
-
-### Adding/Removing Dashboards
-
-To learn how to add or remove dashboards to Grafana please see the
-[examples](../../examples/grafana-add-dashboard) folder.
+[grafana-gh]: https://github.com/grafana/grafana
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/haproxy/README.md
+++ b/katalog/haproxy/README.md
@@ -1,40 +1,17 @@
-# HAproxy Package
+# HAproxy
 
-This package provides a Grafana Dashboard and a set of alert rules for the prometheus exporter built in HAproxy v2 (and not the `haproxy_exporter`).
+<!-- <SD-DOCS> -->
 
-To use this package to monitor an HAproxy battery *outside* the cluster, you must:
+## Overview
 
-1. Check that your haproxy has been built with the built-in prometheus exporter enabled:
+This package provides a Grafana dashboard and a set of Prometheus alert rules for the Prometheus exporter built into HAproxy v2 (not the standalone `haproxy_exporter`). It is intended to monitor an HAproxy battery running outside the cluster: the HAproxy instances must be built with the built-in Prometheus exporter enabled and expose the metrics on a dedicated frontend, then a `ScrapeConfig` resource makes Prometheus scrape those targets.
 
-   ```bash
-   haproxy -vvv | grep prometheus
-   ```
+## Deployment
 
-2. Enable a frontend on HAproxy that exposes the metrics:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
-   ```haproxyconfig
-   frontend prometheus
-     bind :8405
-     mode http
-     http-request use-service prometheus-exporter
-     no log
-   ```
+<!-- </SD-DOCS> -->
 
-3. Create a `ScrapeConfig` object to make Prometheus scrape the metrics from the HAproxy hosts:
+## License
 
-   ```yaml
-   apiVersion: monitoring.coreos.com/v1alpha1
-   kind: ScrapeConfig
-   metadata:
-     name: haproxy-lb
-     namespace: monitoring
-     labels:
-       prometheus: k8s
-   spec:
-     staticConfigs:
-       - labels:
-           job: prometheus
-         targets:
-           - haproxy01.mydomain:8405
-           - haproxy02.mydomain:8405
-   ```
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/kube-proxy-metrics/README.md
+++ b/katalog/kube-proxy-metrics/README.md
@@ -2,45 +2,21 @@
 
 <!-- <SD-DOCS> -->
 
-kube-proxy is a critical piece of any Kubernetes cluster, therefore it is highly
-recommended to gather its metrics. Sometimes (especially in managed clusters) it
-is not possible to configure kube-proxy to be reachable by Prometheus for
-metrics scraping, this is why this package exists. Furthermore, this package
-also adds an authorization layer based on Kubernetes RBAC to the metrics exposed
-by kube-proxy.
+## Overview
 
-## Requirements
+kube-proxy is a critical component of any Kubernetes cluster, so it is highly recommended to gather its metrics. In some environments (especially managed clusters) it is not possible to configure kube-proxy to be reachable by Prometheus for scraping; this package solves that and additionally adds an authorization layer based on Kubernetes RBAC to the metrics exposed by kube-proxy.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
+## Upstream project
 
-## Image repository and tag
-
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.22.0`
-- kube-rbac-proxy repository: [kube-rbac-proxy on Github][krp-gh]
-
-## Configuration
-
-Fury distribution kube-proxy-metrics is deployed with the following configuration:
-
-- Resource limits are `20m` for CPU and `40Mi` for memory
-- Listens on port `18443`
-- Metrics are scraped by Prometheus with `15s` intervals
-- Requires `hostNetwork: true` and `hostPID: true`
-- Runs as non-root user.
+This package is based on the upstream [kube-rbac-proxy][krp-gh].
 
 ## Deployment
 
-You can deploy kube-proxy-metrics by running the following command:
-
-```shell
-kustomize build | kubectl apply -f -
-```
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
 <!-- Links -->
 
-[krp-gh]: https://quay.io/repository/brancz/kube-rbac-proxy
+[krp-gh]: https://github.com/brancz/kube-rbac-proxy
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/kube-state-metrics/README.md
+++ b/katalog/kube-state-metrics/README.md
@@ -2,57 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-This package provides kube-state-metrics service which listens to Kubernetes API
-server and generates metrics about the state of Kubernetes objects like
-Deployments, Nodes, or Pods.
+## Overview
 
-From kube-state-metrics
-[repository](https://github.com/kubernetes/kube-state-metrics):
+kube-state-metrics listens to the Kubernetes API server and generates metrics about the state of Kubernetes objects such as Deployments, Nodes, and Pods. It exposes raw, unmodified data from the Kubernetes API, so users can build their own heuristics on top of it.
 
-> That kube-state-metrics is about generating metrics from Kubernetes API
-> objects without modification. This ensures, that features provided by
-> kube-state-metrics have the same grade of stability as the Kubernetes API
-> objects themselves. In turn, this means, that kube-state-metrics in certain
-> situations may not show the same values as kubectl, as kubectl applies
-> certain heuristics to display comprehensible messages. kube-state-metrics
-> exposes raw data unmodified from the Kubernetes API, this way users have all
-> the data they require and perform heuristics as they see fit.
+## Upstream project
 
-## Requirements
-
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
-
-## Image repository and tag
-
-- kube-state-metrics image: `registry.sighup.io/fury/kube-state-metrics/kube-state-metrics:v2.18.0`
-- kube-state-metrics repository: [kube-state-metrics on GitHub][ksm-gh]
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.21.0`
-- kube-rbac-proxy repository: [kube-rbac-proxy on GitHub][krp-gh]
-
-## Configuration
-
-Fury distribution kube-state-metrics is deployed with the following configuration:
-
-- Resource limits are `100m` for CPU and `150Mi` for memory
-- Listens on port `8080`
-- Exposes kubernetes-related metrics on port `8080` and metrics about itself on
-  port `8081`
-- Metrics are scraped by Prometheus with `30s` intervals
+This package is based on the upstream [kube-state-metrics][ksm-gh].
 
 ## Deployment
 
-You can deploy kube-state-metrics by running the following command:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.monitoring.kubeStateMetrics` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
 [ksm-gh]: https://github.com/kubernetes/kube-state-metrics
-[krp-gh]: https://quay.io/repository/brancz/kube-rbac-proxy
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/kubeadm-sm/README.md
+++ b/katalog/kubeadm-sm/README.md
@@ -2,88 +2,15 @@
 
 <!-- <SD-DOCS> -->
 
-This package provides monitoring for the following Kubernetes components:
+## Overview
 
-- kubelet
-- coredns
-- api-server
-- kube-control-manager
-- kube-scheduler
-- etcd
+This package provides monitoring for the Kubernetes components of self-managed or on-premises clusters: `kubelet`, `coredns`, `api-server`, `kube-controller-manager`, `kube-scheduler` and `etcd`. It ships ServiceMonitors that scrape these components, a set of Grafana dashboards, and Prometheus rules and alerts for the control-plane components, CoreDNS and etcd.
 
-These are components needed to deliver a functioning Kubernetes cluster. If you
-want to learn more about these components, please follow the official
-[documentation](https://kubernetes.io/docs/concepts/overview/components/) of
-Kubernetes.
+> :warning: This package is guaranteed to work only on clusters created using [`kubeadm`](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/). For managed clusters please take a look at the [`aks-sm`](../aks-sm), [`eks-sm`](../eks-sm) and [`gke-sm`](../gke-sm) packages.
 
-> :warning: This package is guaranteed to work only on clusters created using
-> [`kubeadm`](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/),
-> for managed clusters please take a look at the [`aks-sm`](../aks-sm),
-> [`eks-sm`](../eks-sm) and [`gke-sm`](../gke-sm) packages.
+## Deployment
 
-## Requirements
-
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
-
-## Configuration
-
-Prometheus scrapes Kubernetes component metrics on port `metrics` with the following
-intervals:
-
-- kube-control-manager: `30s`
-- coredns: `15s`
-- etcd: `15s`
-- api-server: `30s`
-- kubelet: `30s`
-- kube-scheduler: `30s`
-- Dashboards shipped:
-  - `coredns`: CoreDNS < 1.7.0
-  - `api-server`: Kubernetes / API server
-  - `cluster-total`: Kubernetes / Networking / Cluster
-  - `kubelet`: Kubernetes / Kubelet
-  - `namespace-by-pod`: Kubernetes / Networking / Namespace (Pods)
-  - `namespace-by-workload`: Kubernetes / Networking / Namespace (Workload)
-  - `persistent-volumes-usage`: Kubernetes / Persistent Volumes
-  - `pod-total`: Kubernetes / Networking / Pod
-  - `workload-total`: Kubernetes / Networking / Workload
-  - `controller-manager`: Kubernetes / Controller Manager
-  - `etcd`: Etcd
-  - `scheduler`: Kubernetes / Scheduler
-
-## Alerts
-
-The following alerts are already defined for this package.
-
-### kubernetes-absent-kubeadm
-
-| Parameter                       | Description                                                                                                               | Severity | Interval |
-|---------------------------------|---------------------------------------------------------------------------------------------------------------------------|----------|:--------:|
-| KubeControllerManagerDown       | This alert fires if Prometheus target discovery was not able to reach the kube-controller-manager in the last 15 minutes. | critical |   15m    |
-| KubeSchedulerDown               | This alert fires if Prometheus target discovery was not able to reach the kube-scheduler in the last 15 minutes.          | critical |   15m    |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 30 days.                             | warning  |          |
-| KubeClientCertificateExpiration | This alert fires when the Kubernetes API client certificate is expiring in less than 7 days.                              | critical |          |
-
-### coredns
-
-| Parameter                    | Description                                                                                                      | Severity | Interval |
-|------------------------------|------------------------------------------------------------------------------------------------------------------|----------|:--------:|
-| CoreDNSPanic                 | This alert fires if CoreDNS total panic count increased by at least 1 in the last 10 minutes.                    | warning  |          |
-| CoreDNSRequestsLatency       | This alert fires if CoreDNS 99th percentile requests latency was higher than 100ms in the last 10 minutes.       | warning  |   10m    |
-| CoreDNSHealthRequestsLatency | This alert fires if CoreDNS 99th percentile health requests latency was higher than 10ms in the last 10 minutes. | warning  |   10m    |
-| CoreDNSProxyRequestsLatency  | This alert fires if CoreDNS 99th percentile proxy requests latency was higher than 500ms in the last 10 minutes. | warning  |   10m    |
-
-### etcd3
-
-| Parameter                       | Description                                                                                                  | Severity | Interval |
-|---------------------------------|--------------------------------------------------------------------------------------------------------------|----------|:--------:|
-| EtcdInsufficientMembers         | This alert fires if less than half of Etcd cluster members were online in the last 3 minutes.                | critical |    3m    |
-| EtcdNoLeader                    | This alert fires if the Etcd cluster had no leader in the last minute.                                       | critical |    1m    |
-| EtcdHighNumberOfLeaderChanges   | This alert fires if the Etcd cluster changed leader more than 3 times in the last hour.                      | warning  |          |
-| EtcdHighNumberOfFailedProposals | This alert fires if there were more than 5 proposal failure in the last hour.                                | warning  |          |
-| EtcdHighFsyncDurations          | This alert fires if the WAL fsync 99th percentile latency was higher than 0.5s in the last 10 minutes.       | warning  |   10m    |
-| EtcdHighCommitDurations         | This alert fires if the backend commit 99th percentile latency was higher than 0.25s in the last 10 minutes. | warning  |   10m    |
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/kubeadm-sm/README.md
+++ b/katalog/kubeadm-sm/README.md
@@ -6,7 +6,8 @@
 
 This package provides monitoring for the Kubernetes components of self-managed or on-premises clusters: `kubelet`, `coredns`, `api-server`, `kube-controller-manager`, `kube-scheduler` and `etcd`. It ships ServiceMonitors that scrape these components, a set of Grafana dashboards, and Prometheus rules and alerts for the control-plane components, CoreDNS and etcd.
 
-> :warning: This package is guaranteed to work only on clusters created using [`kubeadm`](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/). For managed clusters please take a look at the [`aks-sm`](../aks-sm), [`eks-sm`](../eks-sm) and [`gke-sm`](../gke-sm) packages.
+> [!WARNING]
+> This package is guaranteed to work only on clusters created using [`kubeadm`](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/). For managed clusters please take a look at the [`aks-sm`](../aks-sm), [`eks-sm`](../eks-sm) and [`gke-sm`](../gke-sm) packages.
 
 ## Deployment
 

--- a/katalog/mimir/README.md
+++ b/katalog/mimir/README.md
@@ -2,43 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-Mimir is an open-source, horizontally scalable, highly available, multi-tenant TSDB for long-term storage for Prometheus.
+## Overview
 
-## Requirements
+Mimir is an open-source, horizontally scalable, highly available, multi-tenant TSDB for long-term storage for Prometheus. It is deployed with a distributed approach (with Ruler, Override exporter and Alertmanager disabled), and Prometheus is patched to remote-write its metrics to Mimir. All time series are ingested in the `fury` tenant, a Grafana data source is installed to query Mimir instead of Prometheus, and by default storage is backed by the [minio-ha](../minio-ha) package.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator from SD monitoring module][prometheus-operator]
-- [grafana from SD monitoring module][grafana]
-- [minio-ha](../minio-ha)
+## Upstream project
 
-## Image repository
-
-- registry.sighup.io/fury/grafana/mimir
-- registry.sighup.io/fury/nginxinc/nginx-unprivileged
-
-## Configuration
-
-Mimir is configured with the distributed approach. We disabled some optional components: Ruler, Override exporter and Alertmanager.
-By default, using this package, Prometheus operated is installed and patched to send metrics to Mimir with the remote write capability.
-
-All the time series are ingested in the `fury` tenant. A Grafana datasource is also installed as default for prometheus type metrics to scrape from Mimir instead of Prometheus.
-
-Also, the storage is configured by default to use the minio-ha package from the monitoring module.
+This package is based on the upstream [Grafana Mimir][mimir-gh].
 
 ## Deployment
 
-You can deploy Mimir by running the following command in the root of
-the project:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.monitoring.mimir` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[prometheus-operator]: https://github.com/sighup-io/fury-kubernetes-monitoring/blob/master/katalog/prometheus-operator
-[grafana]: https://github.com/sighup-io/fury-kubernetes-monitoring/blob/master/katalog/grafana
+[mimir-gh]: https://github.com/grafana/mimir
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/minio-ha/README.md
+++ b/katalog/minio-ha/README.md
@@ -2,44 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-MinIO is a popular distributed object storage system that allows organizations to deploy highly available
-and scalable storage infrastructure.
-To achieve high availability (HA) for MinIO, a cluster of multiple MinIO nodes must be deployed backed by their own set of PVCs.
+## Overview
 
-## Requirements
+MinIO is a distributed object storage system used to deploy highly available and scalable storage. This package deploys MinIO in high-availability mode as a three-Pod StatefulSet (with two PVCs per Pod) and runs an init Job to initialize the buckets and default retention. A `ServiceMonitor` is configured so its metrics are scraped by Prometheus. In the Monitoring Module it provides the default object storage backend for Mimir.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator from SD monitoring module][prometheus-operator]
+## Upstream project
 
-> Prometheus Operator is necessary since we configure a `ServiceMonitor` to make
-> some metrics available from `minio` on prometheus
-
-## Image repository and tag
-
-* MinIO image: `minio/minio`
-* MinIO repo: [MinIO on GitHub][minio-gh]
-
-## Configuration
-
-MinIO HA is deployed in the following configuration:
-
-- Three Pod MinIO statefulset with 2 PVCs per Pod
-- Custom init Job to initialize buckets (`loki` and `errors`)  and default retention (7 days on `errors` bucket)
+This package is based on the upstream [MinIO][minio-gh].
 
 ## Deployment
 
-You can deploy minio-ha by running the following command in the root of
-the project:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.monitoring.minio` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[prometheus-operator]: https://github.com/sighup-io/fury-kubernetes-monitoring/blob/master/katalog/prometheus-operator
 [minio-gh]: https://github.com/minio/minio
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/node-exporter/README.md
+++ b/katalog/node-exporter/README.md
@@ -2,44 +2,21 @@
 
 <!-- <SD-DOCS> -->
 
-This package provides monitoring for hardware and OS metrics exposed by \*NIX
-kernels provided by node-exporter service. You can see a list of collectors
-enabled by default from the project's [repository][ne-gh]
+## Overview
 
-## Requirements
+Node Exporter provides monitoring for hardware and OS metrics exposed by \*NIX kernels. It runs as a DaemonSet and exposes node-level metrics (CPU, memory, filesystem, network and more) that are scraped by Prometheus.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
+## Upstream project
 
-## Image repository and tag
-
-- node-exporter image: `registry.sighup.io/fury/prometheus/node-exporter:v1.10.2`
-- node-exporter repository: [Node-Exporter on GitHub][ne-gh]
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.21.0`
-- kube-rbac-proxy repository: [kube-rbac-proxy on GitHub][krp-gh]
-
-## Configuration
-
-Fury distribution node-exporter is deployed with the following configuration:
-
-- Ignore filesystem mount points starting with `dev|proc|sys|var/lib/docker` (local to the container file system)
-- Ignore filesystem types `autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs`
-- Resource limits are `250m` for CPU and `180Mi` for memory
-- Listens on port `9100`
+This package is based on the upstream [Node Exporter][ne-gh].
 
 ## Deployment
 
-You can deploy node-exporter by running the following command:
-
-```shell
-kustomize build | kubectl apply -f -
-```
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
 <!-- Links -->
 
 [ne-gh]: https://github.com/prometheus/node_exporter
-[krp-gh]: https://quay.io/repository/brancz/kube-rbac-proxy
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/prometheus-adapter/README.md
+++ b/katalog/prometheus-adapter/README.md
@@ -2,48 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-The Prometheus adapter provides an implementation of Kubernetes
-[resource metrics](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/resource-metrics-api.md),
-[custom metrics](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/custom-metrics-api.md), and
-[external metrics](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/external-metrics-api.md) APIs.
+## Overview
 
-This adapter is therefore suitable for use with the autoscaling/v2 Horizontal Pod Auto-scaler in Kubernetes 1.6+.
-It can also replace the [metrics server](https://github.com/kubernetes-incubator/metrics-server) on clusters that already run Prometheus and collect the appropriate metrics.
+The Prometheus Adapter provides an implementation of the Kubernetes resource metrics, custom metrics and external metrics APIs. It is suitable for use with the `autoscaling/v2` Horizontal Pod Autoscaler and can also replace the metrics server on clusters that already run Prometheus.
 
-*Source:* [kubernetes-sigs/prometheus-adapter][pa-gh]
+## Upstream project
 
-## Requirements
-
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
-- [prometheus-operated](../prometheus-operated)
-
-## Image repository and tag
-
-- Prometheus adapter image: `registry.sighup.io/fury/prometheus-adapter/prometheus-adapter:v0.12.0`
-- Prometheus adapter repository: [Prometheus adapter on GitHub][pa-gh]
-
-## Configuration
-
-Fury distribution Prometheus adapter is deployed with the following
-configuration:
-
-- Resource limits are `250m` for CPU and `1024Mi` for memory
-- Listens on port 6443
-- Metrics are scraped from Prometheus every `1m`
+This package is based on the upstream [prometheus-adapter][pa-gh].
 
 ## Deployment
 
-You can deploy prometheus-adapter by running the following command:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build katalog/prometheus-adapter | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.monitoring.prometheusAdapter` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
 [pa-gh]: https://github.com/kubernetes-sigs/prometheus-adapter
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/prometheus-operated/README.md
+++ b/katalog/prometheus-operated/README.md
@@ -2,198 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-Prometheus Operated deploys Prometheus instances via Prometheus CRD as defined
-by [Prometheus Operator](../prometheus-operator).
+## Overview
 
-Prometheus is a monitoring tool to collect metrics-based time series data and
-provides a functional expression language that lets the user select and
-aggregate time-series data in real-time. Prometheus's expression browser makes it
-possible to analyze queried data as a graph or view it as tabular data, but it's
-also possible to integrate it with third-party time-series analytics tools like
-Grafana. Grafana integration is provided in Fury monitoring katalog, please see
-[Grafana](../grafana) package's documentation.
+Prometheus Operated deploys Prometheus instances via the Prometheus CRD defined by the [prometheus-operator](../prometheus-operator). Prometheus is a monitoring tool that collects metrics-based time series data and provides a functional expression language to select and aggregate time series in real time. The deployment ships a set of default Prometheus rules and alerts and is integrated with Grafana for visualization (see the [grafana](../grafana) package).
 
-## Requirements
+## Upstream project
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-- [prometheus-operator](../prometheus-operator)
-
-## Image repository and tag
-
-- Prometheus image: `registry.sighup.io/prometheus/prometheus:v3.10.0`
-- Prometheus repository: [Prometheus on Github][prom-gh]
-- Prometheus documentation: [Prometheus documentation site][prom-doc]
-
-## Configuration
-
-Fury distribution Prometheus is deployed with the following configuration:
-
-- Replica number: `1`
-- Retention for `30` days
-- Retention Storage `120 Gb` (80% of the default 150)
-- Requires `150Gi` storage (with default storage type of Provider)
-- Listens on port `9090`
-- Alertmanager endpoint set to `alertmanager-main`
+This package is based on the upstream [Prometheus][prom-gh].
 
 ## Deployment
 
-You can deploy Prometheus Operated by running the following command:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
-
-To learn how to customize it for your needs please see the
-[examples](../../examples/serviceMonitor) folder.
-
-### Accessing Prometheus UI
-
-You can access to the Prometheus expression browser by port-forwarding on port 9090:
-
-```shell
-kubectl port-forward svc/prometheus-k8s 9090:9090 --namespace monitoring
-```
-
-Now if you go to <http://127.0.0.1:9090> on your browser, you can execute queries
-and visualize query results.
-
-### Service Monitoring
-
-Target discovery is achieved via ServiceMonitor CRD, to learn more about
-ServiceMonitor please follow Prometheus Operator's
-[documentation](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/running-exporters.md).
-
-To learn how to create ServiceMonitor resources for your services please see the [example][example].
-
-### Prometheus Rules and Alerts
-
-Alerting rules are created via PrometheusRule CRD, to learn more about
-PrometheusRule please follow Prometheus Operator
-[documentation](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md)
-and Prometheus
-[documentation](https://github.com/prometheus/prometheus/blob/master/docs/configuration/alerting_rules.md).
-
-To learn how to define alert rules for your services, please see the
-[example](../../examples/prometheus-rules).
-
-## Alerts
-
-The following alerts are already defined for this package.
-
-### kubernetes-apps
-
-| Parameter                         | Description                                                                                                                                                                                                              | Severity | Interval |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | :------: |
-| KubePodCrashLooping               | This alert fires if the per-second rate of the total number of restart of a given pod in a 15 minutes time window was above 0 in the last hour, i.e. the pod is stuck in a crash loop.                                   | warning  |    1h    |
-| KubePodNotReady                   | This alert fires if at least one pod was stuck in the Pending or Unknown phase in the last hour.                                                                                                                         | warning  |    1h    |
-| KubeDeploymentGenerationMismatch  | This alert fires if in the last hour a deployment's observed generation (the revision number recorded in the object status) was different from the metadata generation (the revision number in the deployment metadata). | warning  |   15m    |
-| KubeDeploymentReplicasMismatch    | This alert fires if a deployment's replicas number specification was different from the available replicas in the last hour.                                                                                             | warning  |    1h    |
-| KubeStatefulSetReplicasMismatch   | This alert fires if a deployment's replicas number specification was different from the available replicas in the last hour.                                                                                             | warning  |   15m    |
-| KubeStatefulSetGenerationMismatch | This alert fires if a StatefulSet's replicas number specification was different from the available replicas in the 15 minutes.                                                                                           | warning  |   15m    |
-| KubeDaemonSetRolloutStuck         | This alert fires if the percentage of DaemonSet in the ready phase was less than 100% in the last 15 minutes.                                                                                                            | warning  |   15m    |
-| KubeDaemonSetNotScheduled         | This alert fires if the desired number of scheduled DaemonSet was higher than the number of currently scheduled DaemonSet in the last 10 minutes.                                                                        | warning  |   10m    |
-| KubeDaemonSetMisScheduled         | This alert fires if at least one DaemonSet was running where it was not supposed to run in the last 10 minutes.                                                                                                          | warning  |   10m    |
-| KubeCronJobRunning                | This alert fires if at least one CronJob took more than one hour to complete.                                                                                                                                            | warning  |    1h    |
-| KubeJobCompletion                 | This alert fires if at least on Job took more than one hour to complete.                                                                                                                                                 | warning  |    1h    |
-| KubeJobFailed                     | This alert fires if at least one Job failed in the last hour.                                                                                                                                                            | warning  |    1h    |
-| KubeLatestImageTag                | This alert fires if there are images deployed in the cluster tagged with `:latest` and this is really dangerous                                                                                                          | warning  |    1h    |
-
-### kube-prometheus-node-alerting.rules
-
-| Parameter                         | Description                                                                                                                                                                                       | Severity | Interval |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| NodeCPUSaturating                 | This alert fires if, for a given instance, CPU utilisation and saturation were higher than 90% in the last 30 minutes.                                                                            | warning  |   30m    |
-| NodeCPUStuckInIOWait              | This alert fires if CPU time in IOWait mode calculated on a 5 minutes window for a given instance was more than 50% in the last 15 minutes.                                                       | warning  |   15m    |
-| NodeMemoryRunningFull             | This alert fires if memory utilisation on a given node was higher than 85% in the last 30 minutes.                                                                                                | warning  |   30m    |
-| NodeFilesystemUsageCritical       | This alert fires if in the last minute the filesystem usage was more than 90%.                                                                                                                    | critical |    1m    |
-| NodeFilesystemFullInFourDays      | This alert fires if in the last 5 minutes the filesystem usage was more than 85% and, based on a linear prediction on the volume usage in the last 6 hours, the volume will be full in four days. | warning  |    5m    |
-| NodeFilesystemInodeUsageCritical  | This alert fires if the available inodes in a given filesystem were less than 10% in the last minute.                                                                                             | critical |    1m    |
-| NodeFilesystemInodeFullInFourDays | This alert fires if, based on a linear prediction on the inodes usage in the last 6 hours, the filesystem will exhaust its inodes in four days.                                                   | warning  |    5m    |
-| NodeNetworkDroppingPackets        | This alerts fires if a given physical network interface was dropping more than 10 pkt/s in the last 30 minutes.                                                                                   | warning  |   30m    |
-
-### prometheus
-
-| Parameter                              | Description                                                                                                                                                                              | Severity | Interval |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| PrometheusConfigReloadFailed           | This alert fires if Prometheus's configuration failed to reload in the last 10 minutes.                                                                                                  | critical |   10m    |
-| PrometheusNotificationQueueRunningFull | This alert fires if Prometheus's alert notification queue is running full in the next 30 minutes, based on a linear prediction on the usage in the last 5 minutes.                       | critical |   10m    |
-| PrometheusErrorSendingAlerts           | This alert fires if the error rate calculated in a 5 minutes time windows was more than 1% in the last 10 minutes.                                                                       | critical |   10m    |
-| PrometheusErrorSendingAlerts           | This alert fires if the error rate calculated in a 5 minutes time windows was more than 3% in the last 10 minutes.                                                                       | critical |   10m    |
-| PrometheusNotConnectedToAlertmanagers  | This alert fires if Prometheus was not connected to at least one Alertmanager in the last 10 minutes.                                                                                    | critical |   10m    |
-| PrometheusTSDBReloadsFailing           | This alert fires if Prometheus had any failure to reload data blocks from disk in the last 12 hours.                                                                                     | critical |   12h    |
-| PrometheusTSDBCompactionsFailing       | This alert fires if Prometheus had any failure to compact sample blocks in the last 12 hours.                                                                                            | critical |   12h    |
-| PrometheusTSDBWALCorruptions           | This alert fires if Prometheus had detected any corruption in the write-ahead log in the last 4 hours.                                                                                   | critical |    4h    |
-| PrometheusNotIngestingSamples          | This alert fires if Prometheus sample ingestion rate calculated on a 5 minutes time window was below or equal to 0 in the last 10 minutes, i.e. Prometheus is failing to ingest samples. | critical |   10m    |
-| PrometheusTargetScrapesDuplicate       | This alert fires if Prometheus was discarding many samples due to duplicated timestamps but different values in the last 10 minutes.                                                     | warning  |   10m    |
-
-### general
-
-| Parameter      | Description                                                                                                                                                      | Severity | Interval |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| TargetDown     | This alert fires if more than 10% of the targets were down in the last 10 minutes.                                                                               | critical |   10m    |
-| FdExhaustion   | This alert fires if, based on a linear prediction on file descriptors usage in the last hour minutes, the instance will exhaust its file descriptors in 4 hours. | warning  |   10m    |
-| FdExhaustion   | This alert fires if, based on a linear prediction on file descriptors usage in the last 10 minutes, the instance will exhaust its file descriptors in one hour.  | critical |   10m    |
-| DeadMansSwitch | This is a DeadMansSwitch meant to ensure that the entire Alerting Pipeline is functional.                                                                        | none     |          |
-
-### kubernetes-system
-
-| Parameter           | Description                                                                                                                                                | Severity | Interval |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| KubeNodeNotReady    | This alert fires if a given node was not in Ready status in the last hour.                                                                                 | critical |    1h    |
-| KubeVersionMismatch | This alert fires if the versions of the Kubernetes components were mismatching in the last hour.                                                           | warning  |    1h    |
-| KubeClientErrors    | This alert fires if the Kubernetes API client error responses rate calculated in a 5 minutes window was more than 1% in the last 15 minutes.               | warning  |   15m    |
-| KubeClientErrors    | This alert fires if the Kubernetes API client error responses rate calculated in a 5 minutes window was more than 0.1 errors / sec in the last 15 minutes. | warning  |   15m    |
-| KubeletTooManyPods  | This alert fires if a given kubelet is running more than 100 pods and is approaching the hard limit of 110 pods per node.                                  | warning  |   15m    |
-| KubeAPILatencyHigh  | This alert fires if the API server 99th percentile latency was more than 1 second in the last 10 minutes.                                                  | warning  |   10m    |
-| KubeAPILatencyHigh  | This alert fires if the API server 99th percentile latency was more than 4 second in the last 10 minutes.                                                  | critical |   10m    |
-| KubeAPIErrorsHigh   | This alert fires if the requests error rate calculated in a 5 minutes window was more than 5% in the last 10 minutes.                                      | critical |   10m    |
-
-### kubernetes-storage
-
-| Parameter                               | Description                                                                                                                                 | Severity | Interval |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| KubePersistentVolumeStuck               | This alert fires if a given persisten volume was stuck in the Pending or Failed phase in the last hour.                                     | warning  |    1h    |
-| KubePersistentVolumeUsageCritical       | This alert fires if the available space in a given PersistentVolumeClaim was less than 10% in the last minute.                              | critical |    1m    |
-| KubePersistentVolumeFullInFourDays      | This alert fires if, based on a linear prediction on the volume usage in the last 6 hours, the volume will be full in four days.            | warning  |    5m    |
-| KubePersistentVolumeInodeUsageCritical  | This alert fires if the available inodes in a given PersistentVolumeClaim were less than 10% in the last minute.                            | critical |    1m    |
-| KubePersistentVolumeInodeFullInFourDays | This alert fires if, based on a linear prediction on the inodes usage in the last 6 hours, the volume will exhaust its inodes in four days. | warning  |    5m    |
-
-### kubernetes-absent
-
-| Parameter              | Description                                                                                                           | Severity | Interval |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| AlertmanagerDown       | This alert fires if Prometheus target discovery was not able to reach AlertManager in the last 15 minutes.            | critical |   15m    |
-| KubeAPIDown            | This alert fires if Prometheus target discovery was not able to reach kube-apiserver in the last 15 minutes.          | critical |   15m    |
-| KubeStateMetricsDown   | This alert fires if Prometheus target discovery was not able to reach kube-state-metrics in the last 15 minutes.      | critical |   15m    |
-| KubeletDown            | This alert fires if Prometheus target discovery was not able to reach the kubelet in the last 15 minutes.             | critical |   15m    |
-| NodeExporterDown       | This alert fires if Prometheus target discovery was not able to reach node-exporter in the last 15 minutes.           | critical |   15m    |
-| PrometheusDown         | This alert fires if Prometheus target discovery was not able to reach Prometheus in the last 15 minutes.              | critical |   15m    |
-| PrometheusOperatorDown | This alert fires if Prometheus target discovery was not able to reach the Prometheus Operator in the last 15 minutes. | critical |   15m    |
-
-### alertmanager
-
-| Parameter                      | Description                                                                                                                                     | Severity | Interval |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| AlertmanagerConfigInconsistent | This alert fires if the configuration of the instances of the Alertmanager cluster were out of sync in the last 5 minutes.                      | critical |    5m    |
-| AlertmanagerDownOrMissing      | This alert fires if in the last 5 minutes an unexpected number of Alertmanagers were scraped or Alertmanagers disappered from target discovery. | critical |    5m    |
-| AlertmanagerFailedReload       | This alert fires if the Alertmanager's configuration reload failed in the last 10 minutes.                                                      | critical |   10m    |
-
-### kubernetes-resources
-
-| Parameter         | Description                                                                                                                                                           | Severity | Interval |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| KubeCPUOvercommit | This alert fires if the cluster-wide CPU requests from pods in the last 5 minutes were so high to not tolerate a node failure.                                        | warning  |    5m    |
-| KubeMemOvercommit | This alert fires if the cluster-wide memory requests from pods in the last 5 minutes were so high to not tolerate a node failure.                                     | warning  |    5m    |
-| KubeCPUOvercommit | This alert fires if the hard limit of CPU resources quota in the last 5 minutes is more than 150% of the available resources, i.e. the hard limit is set too high.    | warning  |    5m    |
-| KubeMemOvercommit | This alert fires if the hard limit of memory resources quota in the last 5 minutes is more than 150% of the available resources, i.e. the hard limit is set too high. | warning  |    5m    |
-| KubeQuotaExceeded | This alert fires if a given resource was used for more than 90% of the corresponding hard quota in the last 15 minutes.                                               | warning  |   15m    |
+You can customize it under `spec.distribution.modules.monitoring.prometheus` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
 [prom-gh]: https://github.com/prometheus/prometheus
-[prom-doc]: https://prometheus.io/docs/introduction/overview
-[example]: https://github.com/sighupio/fury-kubernetes-monitoring/examples/serviceMonitor
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/prometheus-operator/README.md
+++ b/katalog/prometheus-operator/README.md
@@ -2,84 +2,21 @@
 
 <!-- <SD-DOCS> -->
 
-Operators are application-specific controllers for complex state-ful
-applications. They are used to having more Kubernetes-native control over
-applications. Prometheus Operator makes it easy to deploy and manage Prometheus
-instances. It also provides easy monitoring definitions for Kubernetes
-services. We can easily deploy Prometheus servers and use advanced options in
-the Prometheus CRD to let the Operator handle version upgrades, persistent
-volume claims, and the discovery of `Alertmanager` instances.
+## Overview
 
-Thanks to Prometheus Operator you don't have to learn Prometheus-specific
-configuration language to monitor your services. Target discovery is achieved
-through `ServiceMonitor` CRD, target configurations are automatically generated
-based on Kubernetes label selectors.
+Prometheus Operator is an application-specific controller that makes it easy to deploy and manage Prometheus instances on Kubernetes. It removes the need to learn Prometheus-specific configuration to monitor services: target discovery is achieved through the `ServiceMonitor` CRD, with scrape configuration generated automatically from Kubernetes label selectors. The operator acts on the `Prometheus`, `ServiceMonitor`, `PrometheusRule` and `Alertmanager` custom resources, handling deployment, version upgrades, persistent volume claims and the discovery of Alertmanager instances.
 
-The Operator acts on the following custom resource definitions
-([CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)):
+## Upstream project
 
-- `Prometheus`: defines the desired Prometheus deployment. It's used by the
-  Operator to deploy Prometheus instances.
-
-- `ServiceMonitor`: declaratively specifies how groups of services should be
-  monitored. The Operator automatically generates Prometheus scrape
-  configuration based on the definition.
-
-- `PrometheusRule`: defines a desired Prometheus rule file, which is going to be
-  loaded by a Prometheus instance containing Prometheus alerting and recording
-  rules.
-
-- `Alertmanager`, defines a desired Alertmanager deployment. It's used by the
-  Operator to deploy AlertManager instances.
-
-The operator takes care of Prometheus deployment and monitors Services, as
-illustrated in this image from the Prometheus Operator repository:
-
-![operator architecture](https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/refs/tags/v0.89.0/Documentation/img/architecture.png)
-
-## Requirements
-
-- Kubernetes >= `1.32.0`
-- Kustomize = `5.6.0`
-
-## Image repository and tag
-
-- Prometheus Operator image: `registry.sighup.io/prometheus-operator/prometheus-operator:v0.89.0`
-- Prometheus Operator repository: [Prometheus Operator on GitHub][prom-op-github]
-- kube-rbac-proxy image: `registry.sighup.io/fury/brancz/kube-rbac-proxy:v0.21.0`
-- kube-rbac-proxy repository: [kube-rbac-proxy on GitHub][krp-gh]
-
-## Configuration
-
-Fury distribution Prometheus Operator is deployed with the following configuration:
-
-- Replica number: `1`
-- Logging to stderr is enabled
-- Resource limits are `200m` for CPU and `200Mi` for memory
-- Listens on port `8080`
+This package is based on the upstream [Prometheus Operator][prom-op-github].
 
 ## Deployment
 
-You can deploy Prometheus Operator by running the following command:
-
-```shell
-kustomize build | kubectl apply -f - --server-side
-```
-
-## Deploying Prometheus
-
-Once Prometheus Operator is deployed, you can deploy Prometheus and Alertmanager
-instances through Operator's CRDs. Then you will be able to monitor and get
-alerts about the services deployed on your Kubernetes cluster. To learn how to
-deploy Prometheus via Operator please see
-[prometheus-operated](../prometheus-operated) documentation. To learn how to
-deploy Alertmanager please see [alertmanager-operated](../alertmanager-operated)
-documentation.
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Monitoring Module is installed and configured.
 
 <!-- Links -->
 
 [prom-op-github]: https://github.com/prometheus-operator/prometheus-operator
-[krp-gh]: https://quay.io/repository/brancz/kube-rbac-proxy
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/x509-exporter/README.md
+++ b/katalog/x509-exporter/README.md
@@ -2,26 +2,26 @@
 
 <!-- <SD-DOCS> -->
 
-This package provides monitoring for certificates.
-The original project is: [x509-certificate-exporter](https://github.com/enix/x509-certificate-exporter)
+## Overview
 
-## Requirements
+The x509 exporter provides monitoring for certificates, exposing metrics about their validity and expiration so they can be scraped by Prometheus and alerted on.
 
-- Kubernetes >= `1.32.0`
-- Kustomize = `v5.6.0`
-- [prometheus-operator](../prometheus-operator)
+## Upstream project
 
-## Image repository and tag
-
-- Certificate exporter image: `registry.sighup.io/fury/enix/x509-certificate-exporter:4.1.0`
+This package is based on the upstream [x509-certificate-exporter][x509-gh].
 
 ## Deployment
 
-You can deploy x509 exporter by running the following command:
+This package is deployed as part of **Monitoring Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.monitoring.x509Exporter` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
+
+<!-- Links -->
+
+[x509-gh]: https://github.com/enix/x509-certificate-exporter
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesmonitoring
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesmonitoring
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesmonitoring
 
 <!-- </SD-DOCS> -->
 


### PR DESCRIPTION
### Summary 💡

This PR replicates the documentation refactor defined in `module-aws` (#104) on this module: the docs are now furyctl/SD-centric and the legacy `Furyfile.yml` + `furyctl legacy vendor` + `kustomize build | kubectl apply` workflow has been removed.

The motivation: this documentation ends up on docs.sighup.io but still described the old legacy workflow and exposed internal implementation details (kustomize patches, raw manifests, image coordinates) that don't make sense on a public docs site.

Relates: sighupio/module-aws#104

### Description 📝

- **`README.md` (SD-DOCS block)**: removed the legacy `Usage`/`Prerequisites`/manual-deployment sections (Furyfile, per-provider ServiceMonitor snippets, `kustomize build | kubectl apply`, Examples-as-deploy). New `Usage` section explains the module is deployed automatically as part of SD by `furyctl`, with an optional `furyctl.yaml` (`spec.distribution.modules.monitoring`) example and links to the configuration schema reference (EKSCluster / KFDDistribution / OnPremises).
- **Slimmed Overview**: condensed to two short paragraphs and removed the verbose controller bullet list and the cloud-provider list.
- **Removed the "Integration with cloud providers" table**: the provider-specific ServiceMonitors (`eks-sm`/`aks-sm`/`gke-sm`/`kubeadm-sm`) are selected and deployed automatically based on the cluster's provider, so they are now mentioned in a single line instead of a manual-selection table.
- **`katalog/*/README.md`**: rewritten to the shared template (Overview → Upstream project → Deployment → License). Removed kustomize/`kubectl apply` instructions, raw manifests, image coordinates and tool prerequisites. Each package's customization claim was checked against the v1alpha2 schema: packages with a dedicated field (`prometheus`, `alertmanager`, `grafana`, `mimir`, `minio`, `prometheusAdapter`, `blackboxExporter`, `kubeStateMetrics`, `x509Exporter`) point to `spec.distribution.modules.monitoring.<field>`; packages without one (prometheus-operator, kube-proxy-metrics, node-exporter, the `*-sm` ServiceMonitors, haproxy, `configs/*`) only point to the module documentation.

### Breaking Changes 💔

None, documentation only.

### Tests performed 🧪

- [x] No `Furyfile` / `furyctl legacy vendor` / `kustomize build | kubectl apply` references left inside the `SD-DOCS` blocks
- [x] `SD-DOCS` / `FOOTER` markers intact, no orphan reference links
- [x] `furyctl.yaml` snippet fields match the v1alpha2 schema; per-package customization claims verified against the schema
- [x] Visual review of the GitHub markdown rendering

### Future work 🔧

- Replicate the same template on the remaining modules.